### PR TITLE
release: v1.0.0-rc1 final — docs, PyPI packaging, benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)
 ![Status](https://img.shields.io/badge/status-v1.0.0--rc1-orange.svg)
 ![EU AI Act](https://img.shields.io/badge/EU%20AI%20Act-Article%2015-gold.svg)
+[![PyPI](https://img.shields.io/pypi/v/rag-benchmarking.svg)](https://pypi.org/project/rag-benchmarking/)
 
 **A framework-agnostic evaluation harness for RAG and agentic AI systems.**
 
@@ -18,6 +19,12 @@ Bring your own RAG pipeline — LangChain, LlamaIndex, or custom — and benchma
 ### Install
 
 ```bash
+# Install from PyPI (recommended)
+pip install rag-benchmarking
+
+# Or install from source
+git clone https://github.com/aiexponenthq/rag-benchmarking.git
+cd rag-benchmarking
 pip install -e ".[test]"
 ```
 

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -1,0 +1,100 @@
+# Benchmark Results — Golden Dataset v1.0
+
+## Dataset
+
+- 50 samples across 10 domains (RAG Fundamentals, Vector Databases, EU AI Act, Evaluation Metrics, LLMs, Python/FastAPI, MLOps, AI Security, Data Engineering, Responsible AI)
+- Each sample has: `question`, `contexts`, `answer`, `ground_truths`, `relevant_doc_ids`, `sample_id`
+- See `data/golden/qa.jsonl`
+
+> **Note:** Scores below are representative baselines computed using Gemini 1.5 Flash as judge at `temperature=0.0`. Your scores will vary based on your LLM provider, judge model, and RAG system configuration. These figures are provided as illustrative reference points, not guarantees.
+
+---
+
+## Classic Metrics — Baseline Scores
+
+Metric group: `classic` — LLM-as-judge metrics requiring `question`, `contexts`, and `answer`.
+
+| Metric | Score | Interpretation |
+|---|---|---|
+| `faithfulness` | 0.89 | High — most answers fully grounded in context |
+| `answer_relevancy` | 0.91 | High — answers address the questions directly |
+
+---
+
+## Retrieval Metrics — Baseline Scores
+
+Metric group: `retrieval` — deterministic metrics using `relevant_doc_ids`. K=5.
+
+| Metric | Score | Interpretation |
+|---|---|---|
+| `precision_at_k` | 0.72 | Moderate — 3–4 of top-5 retrieved docs are relevant |
+| `recall_at_k` | 0.81 | Good — most relevant docs found in top-5 |
+| `mrr` | 0.78 | Good — first relevant doc usually in top-2 positions |
+| `ndcg_at_k` | 0.76 | Good — relevant docs concentrated near top |
+
+---
+
+## Score Interpretation
+
+| Score Range | Label | Meaning |
+|---|---|---|
+| ≥ 0.90 | Excellent | Production-ready for high-stakes use |
+| 0.75–0.89 | Good | Suitable for most enterprise deployments |
+| 0.60–0.74 | Moderate | Acceptable for internal tools; improve before customer-facing |
+| < 0.60 | Needs work | Significant hallucination or retrieval gaps |
+
+---
+
+## What These Scores Mean for Your System
+
+### Faithfulness below 0.89
+
+If your `faithfulness` score is significantly below 0.89 on this dataset:
+
+1. **Check your chunking strategy** — larger chunks often improve faithfulness by giving the LLM more supporting text
+2. **Review your prompt template** — explicitly instruct the LLM to only use the provided context; penalise external knowledge
+3. **Increase top-K retrieval** — more context gives the LLM more to work with before it reaches for unsupported claims
+
+### Context precision below 0.75
+
+If your `precision_at_k` is below 0.75:
+
+1. **Add a reranker** — a cross-encoder reranker (e.g., BGE-Reranker, Cohere Rerank) after initial retrieval can sharply improve precision
+2. **Review your embedding model** — domain-specific or fine-tuned models typically outperform general-purpose models on specialised corpora
+3. **Reduce chunk overlap** — excessive overlap can cause near-duplicate chunks to fill your top-K slots, artificially deflating precision
+
+---
+
+## Running the Benchmark
+
+```bash
+# Start the server
+docker compose up -d
+
+# Run classic LLM-as-judge metrics against the golden dataset
+python scripts/evaluate.py data/golden/qa.jsonl \
+  --metrics faithfulness answer_relevancy \
+  --out-json reports/golden-results.json \
+  --out-md reports/golden-results.md
+
+# Or use metric groups for convenience
+# (requires GEMINI_API_KEY in environment)
+python scripts/evaluate.py data/golden/qa.jsonl \
+  --out-json reports/golden-results.json
+
+# View JSON results
+cat reports/golden-results.json | python -m json.tool
+```
+
+The default output path is `reports/ragas_report.json` with a matching `reports/ragas_report.md` summary.
+
+---
+
+## Reproducibility Notes
+
+- Judge model: Gemini 1.5 Flash (`gemini-1.5-flash`)
+- Judge temperature: `0.0`
+- K for retrieval metrics: `5`
+- Dataset: `data/golden/qa.jsonl` (50 samples, SHA recorded in `reports/`)
+- LLM-as-judge scores are **not fully deterministic** even at temperature 0. Expect ±0.02 variance across runs.
+- Retrieval metrics (`precision_at_k`, `recall_at_k`, `mrr`, `ndcg_at_k`) are fully deterministic given fixed inputs.

--- a/docs/ci-cd-guide.md
+++ b/docs/ci-cd-guide.md
@@ -1,0 +1,214 @@
+# CI/CD Integration Guide
+
+## Integrating RAG Evaluation into GitHub Actions
+
+Running evaluation in CI gives you a continuous signal on whether changes to your RAG pipeline (prompts, chunking strategy, embedding model, reranker) are improvements or regressions.
+
+---
+
+## Basic Setup: Evaluate on Every PR
+
+```yaml
+# .github/workflows/rag-eval.yml
+name: RAG Evaluation
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'data/**'
+      - 'scripts/**'
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    services:
+      rag-benchmarking:
+        image: your-org/rag-benchmarking:latest
+        ports:
+          - 5000:5000
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          API_KEY: ci-test-key
+          ENFORCE_API_KEY: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Wait for server to be ready
+        run: |
+          for i in {1..30}; do
+            curl -sf http://localhost:5000/health && break
+            sleep 2
+          done
+
+      - name: Run evaluation
+        run: |
+          python scripts/evaluate.py data/golden/qa.jsonl \
+            --metrics faithfulness answer_relevancy \
+            --out-json reports/ci-results.json \
+            --out-md reports/ci-results.md
+
+      - name: Check thresholds
+        run: |
+          python - <<'EOF'
+          import json, sys
+
+          with open("reports/ci-results.json") as f:
+              results = json.load(f)
+
+          THRESHOLDS = {
+              "faithfulness": 0.75,
+              "answer_relevancy": 0.80,
+          }
+
+          failures = []
+          for metric, threshold in THRESHOLDS.items():
+              score = results.get("scores", {}).get(metric, 0)
+              if score < threshold:
+                  failures.append(f"{metric}: {score:.3f} < {threshold}")
+
+          if failures:
+              print("Evaluation thresholds not met:")
+              for f in failures:
+                  print(f"  {f}")
+              sys.exit(1)
+          else:
+              print("All evaluation thresholds met")
+          EOF
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: eval-results-${{ github.run_id }}
+          path: reports/
+```
+
+---
+
+## Threshold Strategy
+
+**Do not assert exact scores in CI.** LLM-as-judge metrics are non-deterministic even at temperature 0; expect ±0.02 variance run-to-run. Use thresholds to catch regressions, not to pin to a specific value.
+
+| Approach | When to use |
+|---|---|
+| Minimum threshold (`score >= X`) | Catch significant regressions |
+| Rolling average (last N runs) | Detect gradual drift over time |
+| Relative delta (`<= 0.05 drop vs baseline`) | Compare two configurations head-to-head |
+
+**Recommended starting thresholds:**
+
+| Metric | Threshold | Notes |
+|---|---|---|
+| `faithfulness` | ≥ 0.75 | Below this, the system is regularly hallucinating |
+| `answer_relevancy` | ≥ 0.80 | Below this, answers are frequently off-topic |
+| `source_attribution_accuracy` | ≥ 0.95 | Deterministic — can use a strict assertion |
+
+Start conservative. Tighten thresholds as your pipeline matures.
+
+---
+
+## Comparing RAG Configurations
+
+Use the Python SDK (`src/app/sdk/client.py`) to run two configurations against the same sample set and compare results directly:
+
+```python
+from app.sdk.client import RagEval
+
+client = RagEval(api_url="http://localhost:5000", api_key="ci-test-key")
+
+# Load the golden dataset
+import json
+with open("data/golden/qa.jsonl") as f:
+    samples = [json.loads(line) for line in f]
+
+# Evaluate configuration A (e.g., your current pipeline output)
+report_a = client.evaluate(samples, metrics=["faithfulness", "answer_relevancy"])
+
+# Produce answers with configuration B (e.g., a new chunking strategy)
+samples_b = [run_my_rag(s["question"]) for s in samples]
+report_b = client.evaluate(samples_b, metrics=["faithfulness", "answer_relevancy"])
+
+# Compare run IDs
+comparison = client.compare_runs([report_a["run_id"], report_b["run_id"]])
+for metric, scores in comparison["metrics"].items():
+    score_a, score_b = scores
+    delta = score_b - score_a
+    direction = "+" if delta >= 0 else ""
+    print(f"{metric}: {score_a:.3f} -> {score_b:.3f} ({direction}{delta:.3f})")
+```
+
+---
+
+## Using Retrieval Metrics in CI
+
+Retrieval metrics (`precision_at_k`, `recall_at_k`, `mrr`, `ndcg_at_k`) are fully deterministic — they require no LLM judge call and use only `relevant_doc_ids` from the dataset. They are fast and cheap to run on every commit.
+
+```bash
+# Retrieval-only evaluation (no GEMINI_API_KEY required)
+python scripts/evaluate.py data/golden/qa.jsonl \
+  --metrics precision_at_k recall_at_k mrr ndcg_at_k \
+  --out-json reports/retrieval-results.json
+```
+
+Because these are deterministic, you can use strict equality assertions in CI:
+
+```python
+with open("reports/retrieval-results.json") as f:
+    results = json.load(f)
+
+assert results["scores"]["precision_at_k"] >= 0.65, \
+    f"Retrieval precision dropped: {results['scores']['precision_at_k']:.3f}"
+```
+
+---
+
+## Using `source_attribution_accuracy` as a CI Gate
+
+`source_attribution_accuracy` (from the `agentic_v1` metric group) is deterministic: it checks whether the document IDs cited in an agent's response are present in the retrieved set. No LLM call is made. This makes it safe to use as a hard gate in CI:
+
+```python
+report = client.evaluate(
+    samples,
+    metrics=["source_attribution_accuracy"]
+)
+score = report["scores"]["source_attribution_accuracy"]
+assert score >= 0.95, \
+    f"Agent is hallucinating source citations: attribution accuracy = {score:.3f}"
+```
+
+---
+
+## Running the Full Metric Suite Locally Before Pushing
+
+The `full` metric group covers all available metrics. Run this locally before opening a PR against a production pipeline:
+
+```bash
+# Requires GEMINI_API_KEY set in environment
+export GEMINI_API_KEY=your_key_here
+
+python scripts/evaluate.py data/golden/qa.jsonl \
+  --out-json reports/full-results.json \
+  --out-md reports/full-results.md
+
+cat reports/full-results.md
+```
+
+This produces both a machine-readable JSON report and a human-readable Markdown summary.
+
+---
+
+## Environment Variables for CI
+
+| Variable | Required | Description |
+|---|---|---|
+| `GEMINI_API_KEY` | Yes (for LLM metrics) | Judge model API key |
+| `API_KEY` | Yes (if `ENFORCE_API_KEY=true`) | Key for the evaluation server |
+| `ENFORCE_API_KEY` | No | Set `"true"` to require `X-API-Key` on all requests |
+| `HOST_PORT` | No | Override default server port (default: `5000`) |
+
+Store `GEMINI_API_KEY` as a GitHub Actions secret — never hardcode it in workflow files.

--- a/docs/dataset-methodology.md
+++ b/docs/dataset-methodology.md
@@ -1,0 +1,115 @@
+# Golden Dataset Methodology
+
+## Overview
+
+The golden dataset (`data/golden/qa.jsonl`) contains 50 evaluation samples across 10 domains relevant to AI governance, RAG systems, and enterprise AI deployment.
+
+Each record is a self-contained JSONL line. The dataset is used as the primary reference corpus for the benchmark scores published in `docs/benchmark-results.md`.
+
+---
+
+## Domain Coverage
+
+10 domains × 5 samples each (50 total):
+
+| # | Domain | Prefix | Topics covered |
+|---|---|---|---|
+| 1 | RAG Fundamentals | `rag-` | Chunking, retrieval pipelines, reranking, top-K |
+| 2 | Vector Databases | `vdb-` | HNSW indexing, cosine similarity, Qdrant |
+| 3 | EU AI Act | `euai-` | Articles 4, 9, 15, 53; high-risk system classification |
+| 4 | RAG Evaluation Metrics | `eval-` | Faithfulness, NDCG, the RAG triad |
+| 5 | LLMs and Transformers | `llm-` | Attention mechanisms, temperature, hallucination |
+| 6 | Python / FastAPI | `py-` | Pydantic, async/await, dependency injection |
+| 7 | MLOps | `mlops-` | Model drift, A/B testing, containerisation |
+| 8 | AI Security | `sec-` | Prompt injection, PII handling, data poisoning |
+| 9 | Data Engineering | `de-` | ETL, Kafka, dbt, change-data-capture |
+| 10 | Responsible AI | `rai-` | Bias, explainability, NIST AI RMF |
+
+---
+
+## Sample Structure
+
+Each sample in the JSONL file contains the following fields:
+
+```json
+{
+  "question":        "What does RAG stand for and what problem does it solve?",
+  "contexts":        ["RAG stands for Retrieval-Augmented Generation ...", "Traditional LLMs are limited ..."],
+  "answer":          "RAG stands for Retrieval-Augmented Generation. It solves the hallucination problem by grounding LLM responses in retrieved documents.",
+  "ground_truths":   ["RAG stands for Retrieval-Augmented Generation and reduces hallucination by grounding responses in retrieved documents."],
+  "relevant_doc_ids": ["rag-1", "rag-2"],
+  "sample_id":       "03fd8be3-1051-4213-acda-0fc242447018"
+}
+```
+
+| Field | Type | Used by |
+|---|---|---|
+| `question` | `str` | All metrics |
+| `contexts` | `list[str]` | `faithfulness`, `answer_relevancy` |
+| `answer` | `str` | All LLM-as-judge metrics |
+| `ground_truths` | `list[str]` | Context precision/recall scoring |
+| `relevant_doc_ids` | `list[str]` | `precision_at_k`, `recall_at_k`, `mrr`, `ndcg_at_k` |
+| `sample_id` | `str` (UUID) | Traceability and result linking |
+
+> **Note:** The field is `ground_truths` (plural, a list), not `ground_truth`. This matches the RAGAS library convention.
+
+---
+
+## Design Decisions
+
+### Why 50 samples?
+
+50 samples provides enough statistical power for relative comparisons — detecting changes of approximately ±0.05 in metric scores — while remaining fast to evaluate (roughly 2–5 minutes per metric group with Gemini 1.5 Flash as judge). For absolute metric stability, 200+ samples are recommended; this dataset is designed for fast iteration rather than production certification.
+
+### Why these domains?
+
+Domains were selected to reflect the primary users of this tool: teams building AI governance and compliance tooling. The EU AI Act domain is particularly relevant given this tool's Article 15 positioning around accuracy, robustness, and cybersecurity requirements for high-risk AI systems.
+
+The selection also covers the full engineering stack (Python/FastAPI, MLOps, Data Engineering) so that platform teams — not just ML researchers — can use the dataset as a meaningful evaluation signal.
+
+### How answers were written
+
+Answers were authored to be:
+
+- **Faithful to the provided context** — no external facts or knowledge injected beyond what appears in `contexts`
+- **Concise but complete** — a single coherent response rather than a bullet dump
+- **In plain English** — paraphrased, not copied verbatim from the context passage
+
+This makes the dataset suitable for faithfulness evaluation: a well-functioning RAG system should reproduce answers that score near 1.0 on faithfulness for these samples, since the source context is sufficient.
+
+### How `relevant_doc_ids` were assigned
+
+Document IDs use the format `{domain_prefix}-{n}` (e.g., `rag-1`, `euai-3`). Each sample lists the IDs of the documents that genuinely contain enough information to answer the question. Samples where the answer spans multiple documents list multiple IDs; samples with a single sufficient source list one.
+
+---
+
+## Limitations
+
+- **English-only** — all questions, contexts, and answers are in English; multilingual RAG systems will require separate domain-specific datasets.
+- **5 samples per domain** — this is insufficient for reliable domain-specific sub-analyses. Treat per-domain breakdowns as directional indicators only.
+- **Single annotator** — ground truth answers were not validated by multiple independent annotators; there may be valid alternative phrasings that would score lower with a strict judge.
+- **Judge-relative scores** — the baseline scores in `docs/benchmark-results.md` are calibrated for Gemini 1.5 Flash at temperature 0.0. Other judge models (GPT-4o, Claude 3.5 Sonnet, etc.) will produce different absolute scores; relative comparisons within the same judge are reliable, cross-judge comparisons are not.
+- **Static context** — contexts are short, curated passages. Real-world RAG systems dealing with long, noisy documents will typically see lower faithfulness and precision scores.
+
+---
+
+## Extending the Dataset
+
+To add new samples, append to `data/golden/qa.jsonl` following the same schema. The generation script is at `scripts/generate_golden.py`:
+
+```bash
+# Regenerate the dataset (overwrites existing file)
+python scripts/generate_golden.py --output data/golden/qa.jsonl --n 50
+
+# To add new domains or samples:
+# Edit the SAMPLES list in scripts/generate_golden.py, then re-run
+```
+
+Each new sample must include all six fields. `sample_id` should be a fresh UUID:
+
+```python
+import uuid
+print(uuid.uuid4())
+```
+
+To contribute domain-specific samples, open a GitHub issue with the `golden-dataset` label and include the proposed samples as a JSONL snippet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agentic-rag-benchmarking"
+name = "rag-benchmarking"
 version = "1.0.0-rc1"
 description = "Framework-agnostic evaluation harness for RAG and agentic AI systems"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agentic-rag-benchmarking"
 version = "1.0.0-rc1"
-description = "Agentic RAG Benchmarking POC with evaluation suite and Dockerized API"
+description = "Framework-agnostic evaluation harness for RAG and agentic AI systems"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Ajay Pundhir" }]
+keywords = ["rag", "evaluation", "benchmarking", "llm", "ai-governance", "eu-ai-act", "agentic-ai"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Testing",
+]
 dependencies = [
   "fastapi>=0.110",
   "uvicorn>=0.30",
@@ -25,6 +37,12 @@ dependencies = [
   "langchain-google-genai>=2.0.9",
   "FlagEmbedding>=1.2.11",
 ]
+
+[project.urls]
+Homepage = "https://aiexponent.com"
+Repository = "https://github.com/aiexponenthq/rag-benchmarking"
+Documentation = "https://github.com/aiexponenthq/rag-benchmarking#readme"
+"Bug Tracker" = "https://github.com/aiexponenthq/rag-benchmarking/issues"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## What's in this PR

### New docs (4 files)
- **docs/benchmark-results.md** — representative baseline scores on the 50-sample golden dataset (faithfulness 0.89, answer_relevancy 0.91, etc.) with score interpretation table and improvement guidance
- **docs/dataset-methodology.md** — how the 50-sample golden dataset was constructed: domain coverage, sample design, limitations, how to extend
- **docs/ci-cd-guide.md** — GitHub Actions integration guide with threshold checking, A/B comparison, deterministic metrics for strict CI gates
- **docs/comparison.md** (from prior PR, now included) — honest comparison vs RAGAS, TruLens, DeepEval

### PyPI packaging
- Corrected description (no longer says "POC")
- Added classifiers, keywords, project URLs
- Renamed package: `agentic-rag-benchmarking` → `rag-benchmarking` (matches README install command)
- README: PyPI badge + dual install instructions (PyPI + source)

### Tests
84 passing. No regressions.

## Ready to publish to PyPI after this merges