### PR TITLE
release: v1.0.0 — Path A reframing · schema reconciliation · authenticity pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,16 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e ".[test]"
+        run: pip install -e ".[test]" ruff mypy
+
+      - name: Lint (ruff check)
+        run: python -m ruff check src tests
+
+      - name: Format (ruff format --check)
+        run: python -m ruff format --check src tests
+
+      - name: Type check (mypy, non-blocking for v1.0)
+        run: python -m mypy src || true
 
       - name: Unit tests
         run: python -m pytest tests/unit/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -e ".[test]" ruff mypy
+        run: pip install -e ".[test,lint]"
 
       - name: Lint (ruff check)
         run: python -m ruff check src tests

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,6 +10,15 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true
 
+# Hardened 2026-05-10 to RiskForge parity per Top-N=4 audit C-0.2:
+#  - SBOM (CycloneDX) generated at build time
+#  - Sigstore build-provenance attestation
+#  - GitHub Release created with wheel + sdist + sbom artefacts
+permissions:
+  id-token: write       # PyPI OIDC trusted publishing + Sigstore attestation
+  contents: write       # GitHub Release creation
+  attestations: write   # Build provenance attestation
+
 jobs:
   build:
     name: Build distribution
@@ -25,11 +34,24 @@ jobs:
           pip install build
       - name: Build sdist and wheel
         run: python -m build
+      - name: List built artifacts
+        run: ls -lh dist/
+      - name: Generate CycloneDX SBOM
+        run: |
+          pip install "cyclonedx-bom<5"
+          cyclonedx-py environment -o sbom.cdx.json --format json || \
+          cyclonedx-py environment > sbom.cdx.json || true
+      - name: Attest build provenance (GitHub + Sigstore)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
-          path: dist/
+          path: |
+            dist/
+            sbom.cdx.json
           if-no-files-found: error
 
   publish:
@@ -39,14 +61,33 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/project/rag-benchmarking/
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
-          path: dist/
+          path: ./
       - name: Publish to PyPI (OIDC trusted publisher)
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  release:
+    name: GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: ./
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            sbom.cdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.0.0] - 2026-05-10
+
+First Production/Stable release. Closes the 2026-05-10 Top-N=4 launch readiness audit (Path A: narrowed scope + authenticity-pass cleanup). Full action list at `docs/audit/T-N4-readiness-2026-05-10.md` in the aiexponent monorepo. G6 Responsible AI sign-off pending re-review against this tag.
+
+### Repositioned (regulatory framing)
+
+- **Article 15 framing narrowed.** README + docs no longer assert "audit-ready evidence for Article 15 compliance" — Art. 15 is a tripartite obligation (accuracy + robustness + cybersecurity) and this harness covers only Art. 15(1) accuracy + faithfulness. The cybersecurity scope disclaimer (added in v0.2.x) is now matched by an equally explicit robustness scope disclaimer.
+- **Comparison table updated.** RAGAS gets a "Partial" for agentic metrics (per `docs.ragas.io` Tool call Accuracy) — was incorrectly "No". Promptfoo column added.
+
+### Fixed (production-affecting)
+
+- **Schema reconciliation (RB-H5).** `EvalSample.ground_truths` and `AgentTrace.ground_truths` are now plural-list (Ragas convention), matching the runner, the API request body, the golden dataset, and the methodology docs. The legacy singular `ground_truth=` kwarg still works at construction via a backward-compat shim, and the `.ground_truth` property is preserved as a read-only first-element accessor. **Pasting the documented sample shape no longer raises a Pydantic validation error.**
+- **`METRIC_GROUPS["full"]`** now actually includes every metric group (was missing `context_precision`, `context_recall`, and the entire `agentic_v2` set per audit RB-M9).
+- **`MetricGroup.classic`** now includes `context_precision` + `context_recall` to match the canonical Ragas grouping.
+
+### Changed
+
+- `pyproject.toml` version `1.0.0-rc1` → `1.0.0`; classifier `Beta` → `Production/Stable`.
+- `RunConfig.judge_model` default `gemini-1.5-flash` → `gemini-2.5-flash`. Headline 0.958 / 0.810 figures re-validated against 2.5-flash. Cross-judge absolute comparisons remain unreliable; pin the same judge across runs you compare.
+- `LICENSE` replaced with the verbatim Apache-2.0 SPDX template; copyright moved to a `NOTICE` file per Apache 2.0 §4(d).
+- `publish-pypi.yml` hardened to RiskForge parity: CycloneDX SBOM at build, Sigstore build-provenance attestation, GitHub Release auto-created with wheel + sdist + sbom artefacts.
+- `docs/comparison.md`: Ragas tool_call_accuracy ✗ → ✓ with citation; Promptfoo column added; EU AI Act framing row downgraded to "Partial Art. 15(1) accuracy input".
+- `docs/benchmark-results.md`: retrieval-metric score table removed (audit RB-H3 — scores were retriever-config-dependent, not reproducible); replaced with a `Repro:` command + honest "indicative" note.
+- `docs/dataset-methodology.md`: judge model citations 1.5 → 2.5; "cybersecurity" dropped from the positioning sentence.
+- `DEPLOYMENT.md`: rewritten for v1.0; "POC" framing dropped; legacy `/v1/query` reference removed; `HOST_PORT` default documented as 5001.
+- `docker-compose.yml`: default host port `5000` → `5001` (container internal port stays 5000).
+- `docs/ci-cd-guide.md`: port references aligned to 5001.
+- `SECURITY.md`: SQLite path corrected; supported-versions table updated for 1.0.x.
+- `tool.ruff` line-length 100 → 120 with audit-comment; full `ruff format` applied (23 files, no logic changes).
+- `.github/workflows/ci.yml`: ruff check + ruff format + mypy added (mypy non-blocking for v1.0; flips to required at v1.1).
+- `README.md`: `report["scores"]` → `report["metrics"]` (matches actual return shape); Article 15 section reframed honestly.
+
+### Removed
+
+- Pre-existing committed `eval_results.db` artefact untracked + gitignored.
+
 ## [1.0.0-rc1] — 2026-04-08
 
 ### Breaking Changes

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,12 +1,12 @@
 # Deployment Guide
 
-This guide covers how to deploy the Agentic RAG Benchmarking POC in a production-like environment.
+This guide covers how to deploy `rag-benchmarking` (v1.0.0+) as a self-hosted evaluation service. The CLI/SDK can be used without the server; this guide is specifically for the FastAPI service that exposes `/v1/evaluate`, `/v1/evaluate/agent`, `/v1/runs`, and `/v1/runs/compare`.
 
 ## Prerequisites
 
-- **Docker & Docker Compose**: Required for containerized deployment.
-- **Qdrant Cloud Account**: You need a Qdrant Cloud cluster (or local instance) and an API Key.
-- **LLM Provider API Key**: Gemini (recommended) or OpenAI API Key.
+- **Docker & Docker Compose**: required for containerized deployment.
+- **Qdrant Cloud Account** *(optional)*: only needed if you wire your own retriever in front of the harness. The eval API itself is retriever-agnostic.
+- **LLM Provider API Key**: Gemini (recommended) or OpenAI, used by RAGAS-backed metrics (`faithfulness`, `answer_relevancy`, `context_precision`, `context_recall`) and the LLM-judge agentic metrics. Deterministic metrics (retrieval + `source_attribution_accuracy`) need no LLM key.
 
 ## Configuration
 
@@ -16,73 +16,69 @@ The application is configured via environment variables. Create a `.env` file in
 
 | Variable | Description | Required | Default |
 | :--- | :--- | :--- | :--- |
-| `API_KEY` | **Security**: Master API Key for accessing endpoints. | **Yes** | `None` (Open Mode - Dev Only) |
-| `QDRANT_URL` | URL of your Qdrant instance. | **Yes** | - |
-| `QDRANT_API_KEY` | API Key for Qdrant. | **Yes** | - |
-| `GEMINI_API_KEY` | Google Gemini API Key. | Yes (if using Gemini) | - |
-| `OPENAI_API_KEY` | OpenAI API Key. | Yes (if using OpenAI) | - |
+| `API_KEY` | Master API Key for `/v1/*` endpoints. | **Yes** for production | `None` (open-mode, dev only) |
+| `ENFORCE_API_KEY` | When `true`, requests without `X-API-Key` are rejected. | Recommended `true` | `false` |
+| `GEMINI_API_KEY` | Google Gemini API Key. | Yes (if using Gemini judge) | - |
+| `OPENAI_API_KEY` | OpenAI API Key. | Yes (if using OpenAI judge) | - |
+| `HOST_PORT` | Host-side port for the docker-compose service. Container internal port stays `5000`. | No | `5001` |
 
 ### Tuning Settings
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |
-| `SELF_CHECK_MIN_GROUNDEDNESS` | Threshold (0.0-1.0) for retrying generation. | `0.7` |
-| `SELF_CHECK_RETRY` | Enable/Disable retry logic. | `True` |
 | `LOG_LEVEL` | Logging verbosity (DEBUG, INFO, WARNING, ERROR). | `INFO` |
 
 ## Deployment Options
 
-### 1. Docker Compose (Recommended)
+### 1. Docker Compose (recommended)
 
-This is the standard way to run the service.
+```bash
+docker compose up -d --build
+```
 
-1.  **Build and Run**:
-    ```bash
-    docker compose up -d --build
-    ```
+The API will be available at `http://localhost:5001`. (Container listens on internal `:5000`; the compose file maps it to host `:5001` by default — override with `HOST_PORT=…` if needed.)
 
-2.  **Verify Status**:
-    The API will be available at `http://localhost:5001`.
-    ```bash
-    curl http://localhost:5001/health
-    ```
+```bash
+curl http://localhost:5001/health
+docker compose logs -f rag-api
+```
 
-3.  **Access Logs**:
-    ```bash
-    docker compose logs -f app
-    ```
+### 2. Kubernetes
 
-### 2. Kubernetes (K8s)
+Use the project `Dockerfile`. Mount API keys via a `Secret`, expose via a `Service`/`Ingress`. The container listens on `5000` internally.
 
-For Kubernetes, use the generated `Dockerfile`.
-
-1.  **Build Image**:
-    ```bash
-    docker build -t agentic-rag-benchmarking:latest .
-    ```
-
-2.  **Deploy**:
-    Create a Deployment and Service manifest. Ensure you map the `.env` variables to a Kubernetes `Secret`.
-
-    ```yaml
-    env:
-      - name: API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: rag-secrets
-            key: api-key
-      ...
-    ```
+```yaml
+env:
+  - name: API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: rag-benchmarking-secrets
+        key: api-key
+  - name: ENFORCE_API_KEY
+    value: "true"
+  - name: GEMINI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: rag-benchmarking-secrets
+        key: gemini-api-key
+```
 
 ## Security
 
 > [!IMPORTANT]
-> This application uses a simple API Key header for authentication.
+> This application uses a simple `X-API-Key` header for authentication. There is no built-in user model.
 
-- All clients **MUST** send the `X-API-Key` header with every request to `/v1/query` and `/v1/evaluate`.
-- **Rotations**: To rotate the key, update the `API_KEY` environment variable and restart the service.
+- All clients **must** send `X-API-Key` with every request to `/v1/evaluate`, `/v1/evaluate/agent`, `/v1/runs`, and `/v1/runs/compare` when `ENFORCE_API_KEY=true`.
+- **Key rotation**: update the `API_KEY` env var and restart the service. Old keys are invalidated immediately.
+- The harness makes no outbound calls except to your configured LLM judge provider — see `SECURITY.md` for the full data-flow.
 
 ## Observability
 
-- **Tracing**: The application adds an `X-Trace-Id` header to every response. Include this ID in bug reports.
-- **Logs**: Logs are output in JSON format to `stdout`. Configure your log collector (e.g., Fluentd, Datadog Agent) to parse these JSON lines.
+- **Tracing**: every response carries an `X-Trace-Id` header. Include it in bug reports.
+- **Logs**: JSON to stdout. Wire your log collector (Fluentd, Datadog Agent, Vector) to parse the JSON lines.
+- **Health**: `GET /health` returns `200 OK` once the service is ready to take traffic.
+
+## Versioning + upgrade
+
+- Releases follow [Semantic Versioning](https://semver.org/). Breaking changes bump the major version; metric-definition changes are documented in `CHANGELOG.md` so historical run comparisons remain interpretable.
+- The `eval_results.db` SQLite file is created on first run at the project root by default and is gitignored. Back it up before upgrading if you depend on cross-version run history.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,7 +176,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 Ajay Pundhir
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -188,5 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+RAG Benchmarking
+Copyright 2026 AI Exponent LLC
+
+This product includes software developed at AI Exponent LLC
+(https://aiexponent.com).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sample = {
 }
 
 report = client.evaluate([sample], metrics=["faithfulness", "answer_relevancy"])
-print(report["scores"])
+print(report["metrics"])
 # {"faithfulness": 0.958, "answer_relevancy": 0.810}
 ```
 
@@ -227,34 +227,38 @@ curl -X POST http://localhost:5001/v1/runs/compare \
 
 ---
 
-## EU AI Act Article 15
+## EU AI Act Article 15 — partial input, not conformity evidence
+
+`rag-benchmarking` is an **evaluation harness** that measures **accuracy and faithfulness** for RAG and agentic systems. Those two metrics are *one* input among many that an Article 15 conformity assessment will draw on. They are **not** the conformity assessment itself, and the harness does **not** discharge an Article 15 obligation.
 
 ```mermaid
 graph LR
     RAG["rag-benchmarking\nevaluation harness"]
+    FAITH2["Faithfulness measurement\n(LLM-judge)"]
+    ANS["Answer-relevancy + retrieval metrics\n(deterministic)"]
+    AGENT2["Agentic-trace metrics\n(tool_call_accuracy, source_attribution)"]
+    REPORT2["BenchmarkReport\n→ telemetry input for\nArticle 15(1) accuracy claims"]
 
-    A15["Article 15\nAccuracy · Robustness\nCybersecurity"]
-    FAITH2["Faithfulness testing\n→ measures hallucination rate"]
-    ROBUST["Robustness testing\n→ adversarial + edge case queries"]
-    ATTR["Source attribution\n→ verifies citation accuracy"]
-    REPORT2["BenchmarkReport\n→ audit-ready evidence\nfor Article 15 compliance"]
-
-    RAG --> FAITH2
-    RAG --> ROBUST
-    RAG --> ATTR
-    FAITH2 --> REPORT2
-    ROBUST --> REPORT2
-    ATTR --> REPORT2
-    A15 -.->|"requires"| REPORT2
+    RAG --> FAITH2 --> REPORT2
+    RAG --> ANS --> REPORT2
+    RAG --> AGENT2 --> REPORT2
 
     style RAG fill:#c9a84c,color:#000
-    style A15 fill:#1e3a5f,color:#fff
     style REPORT2 fill:#2d5a2d,color:#fff
 ```
 
-Systematic RAG evaluation produces audit-ready evidence for Article 15's accuracy and robustness requirements.
+### What this tool covers, honestly
 
-> **Scope note — cybersecurity is out of scope.** Article 15 covers three concerns: **accuracy, robustness, and cybersecurity**. `rag-benchmarking` covers the first two. For the cybersecurity leg of Article 15 (adversarial prompt injection, jailbreak resistance, model integrity), pair this tool with a runtime AI security control such as AgentShield. Penalty band for Art. 15 violations: up to **€15M or 3% of global annual turnover** under [Art. 99(4)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689).
+- **Article 15(1) — accuracy declared in instructions for use.** The harness produces faithfulness, answer-relevancy and retrieval-quality metrics that a provider can cite as the empirical basis for the accuracy figures they declare on the system label. The tool does not declare for you, and it does not certify the figures.
+
+### What this tool does NOT cover
+
+- **Article 15 robustness in the regulatory sense.** Robustness under Art. 15 means resilience to errors, faults and inconsistencies — including adversarial-input resilience. This harness has no perturbation generator, no out-of-distribution detector, no adversarial-passage suite. **If a tool tells you it does Art. 15 robustness with a faithfulness scorer, it is overclaiming.**
+- **Article 15 cybersecurity.** Adversarial prompt injection, jailbreak resistance, model-integrity controls. Out of scope. Pair with a runtime AI security control (e.g. AgentShield) for that leg.
+- **Conformity assessment.** Article 15 requires a notified-body conformity assessment for high-risk systems. A benchmark report is not a substitute for that process.
+- **Real-world testing under Art. 60.** The Art. 60 sandboxed-testing regime is a separate procedure with its own supervisory notifications. Out of scope.
+
+> **Penalty band, contextually.** Art. 15 obligations route through the Art. 16 provider-obligation chain to **Art. 99(4)** — up to **€15M or 3% of total worldwide annual turnover, whichever is higher** ([EUR-Lex](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689)). This number is here for context, not as a sales hook. The compliance pathway is broader than this tool.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Bring your own RAG pipeline — LangChain, LlamaIndex, or custom — and benchmark it against classic and agentic-era metrics. Built for teams who need to prove their AI systems work before they ship.
 
-Built by [AI Exponent LLC](https://aiexponent.com). Maps to EU AI Act Article 15 (accuracy requirements).
+Built by [AI Exponent LLC](https://aiexponent.com). Provides **partial Art. 15(1) accuracy input** for high-risk AI systems — not Art. 15 robustness, not cybersecurity, not conformity evidence (see [scope panel](#eu-ai-act-article-15--partial-input-not-conformity-evidence)).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,9 +36,9 @@ We credit reporters in release notes unless they prefer to remain anonymous.
 
 This tool processes RAG evaluation data locally. When using the server:
 
-- Evaluation samples and results are stored in a local SQLite database (`data/benchmark_results.db`)
-- LLM judge calls are made to your configured provider (Gemini or OpenAI) — review their privacy policies
-- No data is sent to AiExponent servers
+- Evaluation samples and results are stored in a local SQLite database (`eval_results.db` at the project root by default; gitignored). The database is created on first run and never sent off-host by the harness itself.
+- LLM judge calls are made to your configured provider (Gemini or OpenAI) — review their privacy policies.
+- No data is sent to AI Exponent LLC servers.
 
 ## Contact
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "${HOST_PORT:-5000}:5000"
+      # Canonical host port is 5001 to match the README + SDK default; the
+      # container internal port stays 5000. Override with HOST_PORT env var.
+      - "${HOST_PORT:-5001}:5000"
     environment:
       - APP_ENV=dev
       - LOG_LEVEL=INFO

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -21,16 +21,29 @@ Metric group: `classic` — LLM-as-judge metrics requiring `question`, `contexts
 
 ---
 
-## Retrieval Metrics — Baseline Scores
+## Retrieval Metrics — indicative, retriever-dependent
 
-Metric group: `retrieval` — deterministic metrics using `relevant_doc_ids`. K=5.
+The retrieval metrics (`precision_at_k`, `recall_at_k`, `mrr`, `ndcg_at_k`) are
+fully deterministic given the inputs, **but the score depends on which retriever
+configuration you run** — embedding model, top-K, corpus index. There is no
+single "RAG Benchmarking baseline" for these metrics: a stronger retriever
+will pull every score higher; a weaker one will pull every score lower.
 
-| Metric | Score | Interpretation |
-|---|---|---|
-| `precision_at_k` | 0.72 | Moderate — 3–4 of top-5 retrieved docs are relevant |
-| `recall_at_k` | 0.81 | Good — most relevant docs found in top-5 |
-| `mrr` | 0.78 | Good — first relevant doc usually in top-2 positions |
-| `ndcg_at_k` | 0.76 | Good — relevant docs concentrated near top |
+Earlier versions of this doc shipped a sample table (precision_at_k 0.72,
+recall_at_k 0.81, mrr 0.78, ndcg_at_k 0.76) without naming the retriever
+configuration. Audit RB-H3 (2026-05-10) flagged that as unreproducible, so
+the table is removed. To get retrieval-metric numbers for your system, run:
+
+```bash
+python scripts/evaluate.py data/golden/qa.jsonl \
+  --metrics precision_at_k recall_at_k mrr ndcg_at_k \
+  --k 5 \
+  --out reports/retrieval_report.json
+```
+
+Both `data/golden/qa.jsonl` (50 samples with `relevant_doc_ids`) and the
+exact retriever you wire in are part of the input — pin them in your run
+record so subsequent runs are comparable.
 
 ---
 
@@ -92,7 +105,7 @@ The default output path is `reports/ragas_report.json` with a matching `reports/
 
 ## Reproducibility Notes
 
-- Judge model: Gemini 1.5 Flash (`gemini-1.5-flash`)
+- Judge model: Gemini 2.5 Flash (`gemini-2.5-flash`). Pinned as the default in `RunConfig.judge_model`. The headline 0.958 / 0.810 figures were re-validated against `gemini-2.5-flash` after `gemini-1.5-flash` was deprecated upstream. Cross-judge absolute comparisons remain unreliable — pin the same judge across runs you compare.
 - Judge temperature: `0.0`
 - K for retrieval metrics: `5`
 - Dataset: `data/golden/qa.jsonl` (50 samples, SHA recorded in `reports/`)

--- a/docs/ci-cd-guide.md
+++ b/docs/ci-cd-guide.md
@@ -26,7 +26,7 @@ jobs:
       rag-benchmarking:
         image: your-org/rag-benchmarking:latest
         ports:
-          - 5000:5000
+          - 5001:5000
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           API_KEY: ci-test-key
@@ -41,7 +41,7 @@ jobs:
       - name: Wait for server to be ready
         run: |
           for i in {1..30}; do
-            curl -sf http://localhost:5000/health && break
+            curl -sf http://localhost:5001/health && break
             sleep 2
           done
 
@@ -119,7 +119,7 @@ Use the Python SDK (`src/app/sdk/client.py`) to run two configurations against t
 ```python
 from app.sdk.client import RagEval
 
-client = RagEval(api_url="http://localhost:5000", api_key="ci-test-key")
+client = RagEval(api_url="http://localhost:5001", api_key="ci-test-key")
 
 # Load the golden dataset
 import json
@@ -209,6 +209,6 @@ This produces both a machine-readable JSON report and a human-readable Markdown 
 | `GEMINI_API_KEY` | Yes (for LLM metrics) | Judge model API key |
 | `API_KEY` | Yes (if `ENFORCE_API_KEY=true`) | Key for the evaluation server |
 | `ENFORCE_API_KEY` | No | Set `"true"` to require `X-API-Key` on all requests |
-| `HOST_PORT` | No | Override default server port (default: `5000`) |
+| `HOST_PORT` | No | Override host port (default: `5001`) — container internal port stays `5000` |
 
 Store `GEMINI_API_KEY` as a GitHub Actions secret — never hardcode it in workflow files.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,22 +2,28 @@
 
 ## Summary
 
-| Feature | RAG Benchmarking | RAGAS | TruLens | DeepEval |
-|---|---|---|---|---|
-| **Framework-agnostic** | Yes — any RAG system via adapter | Partial | Partial | Yes |
-| **LangChain adapter** | Yes | Built-in | Built-in | Yes |
-| **LlamaIndex adapter** | Yes | Built-in | Built-in | Yes |
-| **Classic RAG metrics** | Yes (faithfulness, answer_relevancy, context_precision/recall) | Yes | Yes | Yes |
-| **Retrieval metrics** | Yes (Precision@K, Recall@K, MRR, NDCG) | No | Partial | Partial |
-| **Agentic-era metrics** | Yes (4 metrics: agent_faithfulness, tool_call_accuracy, retrieval_necessity, source_attribution) | No | No | Partial |
-| **LLM-as-judge** | Yes (Gemini, OpenAI) | Yes | Yes | Yes |
-| **Deterministic metrics** | Yes (source_attribution_accuracy) | No | No | Yes |
-| **REST API** | Yes (FastAPI, API key auth) | No | No | No |
-| **Python SDK** | Yes | Direct library | Direct library | Direct library |
-| **Run comparison** | Yes (SQLite, /v1/runs/compare) | No | Yes (dashboard) | No |
-| **Self-hosted** | Yes (Docker Compose) | Yes | Yes | Yes |
-| **EU AI Act framing** | Yes (Article 15 mapping) | No | No | No |
-| **Open source** | Yes (Apache 2.0) | Yes (MIT) | Yes (MIT) | Yes (Apache 2.0) |
+| Feature | RAG Benchmarking | RAGAS | TruLens | DeepEval | Promptfoo |
+|---|---|---|---|---|---|
+| **Framework-agnostic** | Yes — any RAG system via adapter | Partial | Partial | Yes | Yes |
+| **LangChain adapter** | Yes | Built-in | Built-in | Yes | Yes |
+| **LlamaIndex adapter** | Yes | Built-in | Built-in | Yes | Partial |
+| **Classic RAG metrics** | Yes (faithfulness, answer_relevancy, context_precision/recall) | Yes | Yes | Yes | Partial |
+| **Retrieval metrics** | Yes (Precision@K, Recall@K, MRR, NDCG) | No | Partial | Partial | No |
+| **Agentic-era metrics** | Yes (4 metrics: agent_faithfulness, tool_call_accuracy, retrieval_necessity, source_attribution) | Partial (Tool call Accuracy per docs.ragas.io) | No | Partial | No |
+| **LLM-as-judge** | Yes (Gemini, OpenAI) | Yes | Yes | Yes | Yes |
+| **Deterministic metrics** | Yes (source_attribution_accuracy) | No | No | Yes | Yes |
+| **REST API** | Yes (FastAPI, API key auth) | No | No | No | No (CLI / yaml) |
+| **Python SDK** | Yes | Direct library | Direct library | Direct library | Yes |
+| **Run comparison** | Yes (SQLite, /v1/runs/compare) | No | Yes (dashboard) | No | Yes (web UI) |
+| **Self-hosted** | Yes (Docker Compose) | Yes | Yes | Yes | Yes |
+| **EU AI Act framing** | Partial Art. 15(1) accuracy input | No | No | No | No |
+| **Open source** | Yes (Apache 2.0) | Yes (Apache 2.0) | Yes (MIT) | Yes (Apache 2.0) | Yes (MIT) |
+
+> **Note (audit 2026-05-10):** RAGAS's stable docs at docs.ragas.io list `Tool call Accuracy`
+> under the *Agents or Tool use cases* section, so the agentic-metrics row is honestly
+> "Partial" rather than "No". An earlier version of this table had RAGAS at "No" — fixed.
+> Promptfoo column added; it is primarily a prompt-evaluation framework with some RAG
+> support, so RAG-specific metrics show up as Partial / No rather than direct competitors.
 
 ---
 
@@ -118,7 +124,7 @@ DeepEval is a testing framework with pytest integration and a large metric libra
 | MRR | ✓ | ✗ | ✗ | ✗ |
 | NDCG | ✓ | ✗ | ✗ | ✗ |
 | Agent Faithfulness | ✓ | ✗ | ✗ | Partial |
-| Tool Call Accuracy | ✓ | ✗ | ✗ | ✓ |
+| Tool Call Accuracy | ✓ | ✓ (per docs.ragas.io) | ✗ | ✓ |
 | Source Attribution | ✓ (deterministic) | ✗ | ✗ | ✗ |
 | Retrieval Necessity | ✓ | ✗ | ✗ | ✗ |
 | Custom metrics | Via plugin | Via custom metrics | Via feedback functions | Via G-Eval |

--- a/docs/dataset-methodology.md
+++ b/docs/dataset-methodology.md
@@ -59,11 +59,11 @@ Each sample in the JSONL file contains the following fields:
 
 ### Why 50 samples?
 
-50 samples provides enough statistical power for relative comparisons — detecting changes of approximately ±0.05 in metric scores — while remaining fast to evaluate (roughly 2–5 minutes per metric group with Gemini 1.5 Flash as judge). For absolute metric stability, 200+ samples are recommended; this dataset is designed for fast iteration rather than production certification.
+50 samples provides enough statistical power for relative comparisons — detecting changes of approximately ±0.05 in metric scores — while remaining fast to evaluate (roughly 2–5 minutes per metric group with Gemini 2.5 Flash as judge). For absolute metric stability, 200+ samples are recommended; this dataset is designed for fast iteration rather than production certification.
 
 ### Why these domains?
 
-Domains were selected to reflect the primary users of this tool: teams building AI governance and compliance tooling. The EU AI Act domain is particularly relevant given this tool's Article 15 positioning around accuracy, robustness, and cybersecurity requirements for high-risk AI systems.
+Domains were selected to reflect the primary users of this tool: teams building AI governance and compliance tooling. The EU AI Act domain is particularly relevant given this tool's positioning as **partial Article 15(1) accuracy input** for high-risk AI systems. Robustness in the regulatory sense and cybersecurity are out of scope for this harness — those legs of Article 15 require dedicated tooling (see the README scope note).
 
 The selection also covers the full engineering stack (Python/FastAPI, MLOps, Data Engineering) so that platform teams — not just ML researchers — can use the dataset as a meaningful evaluation signal.
 
@@ -88,7 +88,7 @@ Document IDs use the format `{domain_prefix}-{n}` (e.g., `rag-1`, `euai-3`). Eac
 - **English-only** — all questions, contexts, and answers are in English; multilingual RAG systems will require separate domain-specific datasets.
 - **5 samples per domain** — this is insufficient for reliable domain-specific sub-analyses. Treat per-domain breakdowns as directional indicators only.
 - **Single annotator** — ground truth answers were not validated by multiple independent annotators; there may be valid alternative phrasings that would score lower with a strict judge.
-- **Judge-relative scores** — the baseline scores in `docs/benchmark-results.md` are calibrated for Gemini 1.5 Flash at temperature 0.0. Other judge models (GPT-4o, Claude 3.5 Sonnet, etc.) will produce different absolute scores; relative comparisons within the same judge are reliable, cross-judge comparisons are not.
+- **Judge-relative scores** — the baseline scores in `docs/benchmark-results.md` are calibrated for Gemini 2.5 Flash at temperature 0.0. Other judge models (GPT-4o, Claude 3.5 Sonnet, etc.) will produce different absolute scores; relative comparisons within the same judge are reliable, cross-judge comparisons are not.
 - **Static context** — contexts are short, curated passages. Real-world RAG systems dealing with long, noisy documents will typically see lower faithfulness and precision scores.
 
 ---

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -175,7 +175,7 @@ curl -s -X POST http://localhost:5001/v1/evaluate \
       "question": "What does Article 53 of the EU AI Act require?",
       "contexts": ["Article 53 requires GPAI model providers to publish technical documentation, comply with copyright law, and publish summaries of training data used."],
       "answer": "Article 53 requires GPAI providers to publish technical documentation and training data summaries.",
-      "ground_truth": "Article 53 requires GPAI model providers to publish technical documentation and training data summaries."
+      "ground_truths": ["Article 53 requires GPAI model providers to publish technical documentation and training data summaries."]
     }],
     "metrics": ["faithfulness", "answer_relevancy", "context_precision", "context_recall"]
   }' | python -m json.tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rag-benchmarking"
-version = "1.0.0-rc1"
+version = "1.0.0"
 description = "Framework-agnostic evaluation harness for RAG and agentic AI systems"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Ajay Pundhir" }]
 keywords = ["rag", "evaluation", "benchmarking", "llm", "ai-governance", "eu-ai-act", "agentic-ai"]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
@@ -61,12 +61,15 @@ include = ["app*", "harness*"]
 exclude = []
 
 [tool.black]
-line-length = 100
+line-length = 120
 target-version = ["py311"]
 skip-string-normalization = true
 
 [tool.ruff]
-line-length = 100
+# Bumped from 100 → 120 for v1.0 (audit RB-D9). The pre-existing codebase
+# had 19 E501 lines at 101–130 chars; rather than wrap those mechanically
+# we accept the modern 120-char convention and enforce it as the new floor.
+line-length = 120
 target-version = "py311"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,15 @@ test = [
   "pytest-cov>=5.0",
   "httpx>=0.27",
 ]
+# Lint/type tools pinned so CI lint runs are deterministic across the
+# release window. New ruff rules (UP042, stricter I001 import-sort) shipped
+# while this PR was open and surfaced as CI red on a tree that was clean
+# under the prior version. Pinning here means a deliberate version bump
+# is needed to flip new rules on, which is the right authoring loop.
+lint = [
+  "ruff==0.15.12",
+  "mypy>=1.10",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/app/api/evaluate.py
+++ b/src/app/api/evaluate.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from harness.schemas import AgentTrace
 from pydantic import BaseModel, Field
 
 from app.api.security import get_api_key
 from app.eval.reporting import write_report_files
 from app.eval.result_store import ResultStore
+from harness.schemas import AgentTrace
 
 router = APIRouter(prefix="/v1", tags=["evaluate"])
 

--- a/src/app/api/evaluate.py
+++ b/src/app/api/evaluate.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from harness.schemas import AgentTrace
 from pydantic import BaseModel, Field
 
 from app.api.security import get_api_key
 from app.eval.reporting import write_report_files
 from app.eval.result_store import ResultStore
-from harness.schemas import AgentTrace
 
 router = APIRouter(prefix="/v1", tags=["evaluate"])
 
@@ -45,7 +45,8 @@ async def post_evaluate(req: EvalRequest, _: str | None = Depends(get_api_key)) 
     the FastAPI event loop.
     """
     from harness.runner import EvaluationRunner
-    from harness.schemas import EvalSample as HarnessEvalSample, RunConfig
+    from harness.schemas import EvalSample as HarnessEvalSample
+    from harness.schemas import RunConfig
 
     loop = asyncio.get_running_loop()
     try:
@@ -55,7 +56,7 @@ async def post_evaluate(req: EvalRequest, _: str | None = Depends(get_api_key)) 
                 question=s.question,
                 contexts=s.contexts,
                 answer=s.answer,
-                ground_truth=s.ground_truths[0] if s.ground_truths else None,
+                ground_truths=s.ground_truths,
             )
             for s in req.samples
         ]
@@ -75,7 +76,11 @@ async def post_evaluate(req: EvalRequest, _: str | None = Depends(get_api_key)) 
         }
 
         paths = write_report_files(
-            {"metrics": result.metrics, "per_sample": {}, "skipped_metrics": result.skipped_metrics},
+            {
+                "metrics": result.metrics,
+                "per_sample": {},
+                "skipped_metrics": result.skipped_metrics,
+            },
             out_json=Path(req.out_json) if req.out_json else None,
             out_md=Path(req.out_md) if req.out_md else None,
         )
@@ -88,9 +93,7 @@ async def post_evaluate(req: EvalRequest, _: str | None = Depends(get_api_key)) 
 
 class AgentEvalRequest(BaseModel):
     trace: AgentTrace
-    metrics: list[str] = Field(
-        default=["source_attribution_accuracy", "agent_faithfulness", "tool_call_accuracy"]
-    )
+    metrics: list[str] = Field(default=["source_attribution_accuracy", "agent_faithfulness", "tool_call_accuracy"])
 
 
 @router.post("/evaluate/agent")
@@ -101,19 +104,19 @@ async def post_evaluate_agent(
     """Evaluate an agentic RAG trace using agentic-specific metrics."""
     import re
 
-    from app.eval.agentic_metrics import source_attribution_accuracy
     from app.eval.agentic_llm_metrics import (
         compute_agent_faithfulness,
         compute_retrieval_necessity,
         compute_tool_call_accuracy,
     )
+    from app.eval.agentic_metrics import source_attribution_accuracy
 
     scores: dict[str, float] = {}
     details: dict[str, Any] = {}
 
     for metric in request.metrics:
         if metric == "source_attribution_accuracy":
-            cited = re.findall(r'\[source:\s*([^\]]+)\]', request.trace.final_answer)
+            cited = re.findall(r"\[source:\s*([^\]]+)\]", request.trace.final_answer)
             retrieved = [c.source_id for c in request.trace.retrieved_chunks]
             r = source_attribution_accuracy(cited, retrieved)
             scores[metric] = r["score"]

--- a/src/app/api/query.py
+++ b/src/app/api/query.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -31,9 +30,7 @@ def get_rag_engine() -> RAGEngine:
 
 
 @router.post("/query", response_model=QueryResponse)
-async def post_query(
-    req: QueryRequest, engine: RAGEngine = Depends(get_rag_engine)
-) -> QueryResponse:
+async def post_query(req: QueryRequest, engine: RAGEngine = Depends(get_rag_engine)) -> QueryResponse:
     """Async query endpoint.
 
     ``RAGEngine.query()`` calls sentence-transformers (CPU-bound / sync) and
@@ -58,9 +55,7 @@ async def post_query(
     # attribute may be a Mock object rather than a dict.
     _raw = getattr(getattr(engine, "llm", None), "_last_token_usage", None)
     last_usage: dict[str, int] = (
-        _raw
-        if isinstance(_raw, dict)
-        else {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        _raw if isinstance(_raw, dict) else {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     )
 
     return QueryResponse(

--- a/src/app/config/settings.py
+++ b/src/app/config/settings.py
@@ -50,9 +50,7 @@ class AppSettings(BaseSettings):
 
     # Prompts
     system_prompt: str = Field(
-        default=(
-            "You are a helpful assistant. Answer based only on the provided context. Cite sources."
-        ),
+        default=("You are a helpful assistant. Answer based only on the provided context. Cite sources."),
         alias="SYSTEM_PROMPT",
     )
     user_prompt_template: str = Field(

--- a/src/app/engine/rag_engine.py
+++ b/src/app/engine/rag_engine.py
@@ -34,7 +34,7 @@ class RAGEngine:
 
     def query(self, query: str, top_k: int, rerank: bool) -> RAGResult:
         """
-        Execute the full RAG pipeline including retrieval, reranking, generation, 
+        Execute the full RAG pipeline including retrieval, reranking, generation,
         and optional retry.
         """
         timings: dict[str, float] = {}
@@ -76,9 +76,7 @@ class RAGEngine:
             from app.quality.self_check import compute_groundedness
 
             with timer() as t_sc:
-                groundedness = compute_groundedness(
-                    answer, [c.get("text", "") for c in current_chunks]
-                )
+                groundedness = compute_groundedness(answer, [c.get("text", "") for c in current_chunks])
             timings["self_check"] = t_sc["elapsed_ms"]
         except Exception:
             pass
@@ -89,7 +87,6 @@ class RAGEngine:
             and groundedness < self.settings.self_check_min_groundedness
             and self.settings.self_check_retry
         ):
-
             logger.info(
                 "Groundedness below threshold, attempting retry",
                 extra={
@@ -125,22 +122,14 @@ class RAGEngine:
             for c in current_chunks
         ]
 
-        return RAGResult(
-            answer=answer, citations=citations, timings=timings, groundedness=groundedness
-        )
+        return RAGResult(answer=answer, citations=citations, timings=timings, groundedness=groundedness)
 
     def _call_llm(self, query: str, chunks: list[dict[str, Any]]) -> str:
-        context_blocks = "\n\n".join(
-            [f"[source: {c.get('source_id','')}]\n{c.get('text','')}" for c in chunks]
-        )
-        user_prompt = self.settings.user_prompt_template.format(
-            context_blocks=context_blocks, query=query
-        )
+        context_blocks = "\n\n".join([f"[source: {c.get('source_id','')}]\n{c.get('text','')}" for c in chunks])
+        user_prompt = self.settings.user_prompt_template.format(context_blocks=context_blocks, query=query)
         return self.llm.generate(self.settings.system_prompt, user_prompt)
 
-    def _retry_workflow(
-        self, query: str, top_k: int, rerank: bool, current_score: float
-    ) -> dict[str, Any] | None:
+    def _retry_workflow(self, query: str, top_k: int, rerank: bool, current_score: float) -> dict[str, Any] | None:
         timings = {}
 
         # Expand retrieval
@@ -172,9 +161,7 @@ class RAGEngine:
             from app.quality.self_check import compute_groundedness
 
             with timer() as t_sc:
-                groundedness = compute_groundedness(
-                    answer, [c.get("text", "") for c in more_chunks]
-                )
+                groundedness = compute_groundedness(answer, [c.get("text", "") for c in more_chunks])
             timings["self_check_retry"] = t_sc["elapsed_ms"]
         except Exception:
             return None

--- a/src/app/engine/rag_engine.py
+++ b/src/app/engine/rag_engine.py
@@ -125,7 +125,7 @@ class RAGEngine:
         return RAGResult(answer=answer, citations=citations, timings=timings, groundedness=groundedness)
 
     def _call_llm(self, query: str, chunks: list[dict[str, Any]]) -> str:
-        context_blocks = "\n\n".join([f"[source: {c.get('source_id','')}]\n{c.get('text','')}" for c in chunks])
+        context_blocks = "\n\n".join([f"[source: {c.get('source_id', '')}]\n{c.get('text', '')}" for c in chunks])
         user_prompt = self.settings.user_prompt_template.format(context_blocks=context_blocks, query=query)
         return self.llm.generate(self.settings.system_prompt, user_prompt)
 

--- a/src/app/eval/agentic_llm_metrics.py
+++ b/src/app/eval/agentic_llm_metrics.py
@@ -4,9 +4,8 @@ import json
 import logging
 from typing import Any
 
-from harness.schemas import AgentTrace
-
 from app.llm.client import LLMClient
+from harness.schemas import AgentTrace
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/eval/agentic_llm_metrics.py
+++ b/src/app/eval/agentic_llm_metrics.py
@@ -4,8 +4,9 @@ import json
 import logging
 from typing import Any
 
-from app.llm.client import LLMClient
 from harness.schemas import AgentTrace
+
+from app.llm.client import LLMClient
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,8 @@ def _call_judge(system: str, user: str) -> dict[str, Any]:
 
 _AGENT_FAITHFULNESS_SYSTEM = """You are evaluating factual consistency across an AI agent's full reasoning trace.
 
-For each reasoning step, verify every factual claim is supported by the tool output at that step or a previously retrieved source.
+For each reasoning step, verify every factual claim is supported by the tool output at that step
+or a previously retrieved source.
 A claim is NOT supported if it appears in the reasoning but not in any tool output, or contradicts the tool output.
 
 Return JSON only:
@@ -82,12 +84,11 @@ def compute_agent_faithfulness(trace: AgentTrace) -> dict:
         }
 
     steps_text = "\n\n".join(
-        f"Step {s.step_index}: {s.thought}\nObservation: {s.observation}"
-        for s in trace.reasoning_steps
+        f"Step {s.step_index}: {s.thought}\nObservation: {s.observation}" for s in trace.reasoning_steps
     )
-    sources_text = "\n\n".join(
-        f"[{c.source_id}]: {c.content}" for c in trace.retrieved_chunks
-    ) or "No explicit chunks provided."
+    sources_text = (
+        "\n\n".join(f"[{c.source_id}]: {c.content}" for c in trace.retrieved_chunks) or "No explicit chunks provided."
+    )
 
     user = f"FULL AGENT TRACE:\n{steps_text}\n\nSOURCES:\n{sources_text}"
     data = _call_judge(_AGENT_FAITHFULNESS_SYSTEM, user)
@@ -110,8 +111,7 @@ def compute_tool_call_accuracy(trace: AgentTrace) -> dict:
         return {"score": 1.0, "tool_evaluations": []}
 
     calls_text = "\n".join(
-        f"Step {tc.step_index}: {tc.tool_name}({tc.tool_input}) → {tc.tool_output[:200]}"
-        for tc in trace.tool_calls
+        f"Step {tc.step_index}: {tc.tool_name}({tc.tool_input}) → {tc.tool_output[:200]}" for tc in trace.tool_calls
     )
     user = (
         f"QUESTION: {trace.question}\n\n"
@@ -136,11 +136,7 @@ def compute_retrieval_necessity(
     High score = retrieval was essential; low score = retrieval was unnecessary.
     """
     context_text = "\n\n".join(contexts)
-    user = (
-        f"QUESTION: {question}\n\n"
-        f"RETRIEVED CONTEXT:\n{context_text}\n\n"
-        f"FINAL ANSWER: {answer}"
-    )
+    user = f"QUESTION: {question}\n\nRETRIEVED CONTEXT:\n{context_text}\n\nFINAL ANSWER: {answer}"
     data = _call_judge(_NECESSITY_SYSTEM, user)
     score = float(data.get("score", 0.0))
     return {

--- a/src/app/eval/agentic_metrics.py
+++ b/src/app/eval/agentic_metrics.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/app/eval/ragas_runner.py
+++ b/src/app/eval/ragas_runner.py
@@ -53,15 +53,10 @@ def run_evaluation(
     # ------------------------------------------------------------------ #
     # Determine which metrics to run                                       #
     # ------------------------------------------------------------------ #
-    all_requested = list(
-        metrics
-        or ["faithfulness", "answer_relevancy", "context_precision", "context_recall"]
-    )
+    all_requested = list(metrics or ["faithfulness", "answer_relevancy", "context_precision", "context_recall"])
 
     # Retrieval metrics need ground truth — inspect first sample to decide
-    has_ground_truth = any(
-        bool(s.get("ground_truths") or s.get("reference")) for s in samples
-    )
+    has_ground_truth = any(bool(s.get("ground_truths") or s.get("reference")) for s in samples)
 
     RETRIEVAL_METRICS = {"context_precision", "context_recall"}
     selected: list[str] = []
@@ -91,9 +86,7 @@ def run_evaluation(
     ragas_samples: list[SingleTurnSample] = []
     for s in samples:
         ground_truth_list: list[str] = s.get("ground_truths") or []
-        reference: str | None = s.get("reference") or (
-            ground_truth_list[0] if ground_truth_list else None
-        )
+        reference: str | None = s.get("reference") or (ground_truth_list[0] if ground_truth_list else None)
         ragas_samples.append(
             SingleTurnSample(
                 user_input=s.get("user_input") or s.get("question", ""),
@@ -108,17 +101,16 @@ def run_evaluation(
     # ------------------------------------------------------------------ #
     # Configure judge LLM (LangChain wrapper for RAGAS 0.4.x)             #
     # ------------------------------------------------------------------ #
-    from app.config.settings import get_settings as _get_settings
     from langchain_google_genai import ChatGoogleGenerativeAI
     from ragas.llms import LangchainLLMWrapper
+
+    from app.config.settings import get_settings as _get_settings
 
     _settings = _get_settings()
 
     gemini_api_key = _settings.gemini_api_key or os.getenv("GEMINI_API_KEY")
     if not gemini_api_key:
-        raise RuntimeError(
-            "GEMINI_API_KEY is required. Set it in your .env file."
-        )
+        raise RuntimeError("GEMINI_API_KEY is required. Set it in your .env file.")
 
     _gemini_model = _settings.gemini_model or "gemini-2.5-flash"
 
@@ -142,9 +134,8 @@ def run_evaluation(
     # so it never falls back to OpenAI embeddings.
     from langchain_community.embeddings import HuggingFaceEmbeddings
     from ragas.embeddings import LangchainEmbeddingsWrapper
-    _hf_embeddings = LangchainEmbeddingsWrapper(
-        HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
-    )
+
+    _hf_embeddings = LangchainEmbeddingsWrapper(HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2"))
     for metric in metric_objs:
         if hasattr(metric, "embeddings"):
             metric.embeddings = _hf_embeddings
@@ -162,6 +153,7 @@ def run_evaluation(
 
     import logging as _logging
     import math as _math
+
     _logger = _logging.getLogger(__name__)
 
     try:
@@ -197,8 +189,6 @@ def run_evaluation(
         "per_sample": per_sample,
         "skipped_metrics": skipped,
         "skip_reason": (
-            "ground_truths not provided — context_precision and context_recall require reference"
-            if skipped
-            else None
+            "ground_truths not provided — context_precision and context_recall require reference" if skipped else None
         ),
     }

--- a/src/app/eval/result_store.py
+++ b/src/app/eval/result_store.py
@@ -136,7 +136,7 @@ class ResultStore:
 
         with self._conn() as conn:
             conn.execute(
-                "INSERT INTO runs (run_id, created_at, metrics, n_samples, skipped) " "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO runs (run_id, created_at, metrics, n_samples, skipped) VALUES (?, ?, ?, ?, ?)",
                 (
                     run_id,
                     now,
@@ -183,7 +183,7 @@ class ResultStore:
         """Return summary rows for recent runs, newest first."""
         with self._conn() as conn:
             rows = conn.execute(
-                "SELECT run_id, created_at, metrics, n_samples, skipped " "FROM runs ORDER BY id DESC LIMIT ?",
+                "SELECT run_id, created_at, metrics, n_samples, skipped FROM runs ORDER BY id DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [

--- a/src/app/eval/result_store.py
+++ b/src/app/eval/result_store.py
@@ -40,11 +40,11 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Generator
-
+from typing import Any
 
 _DEFAULT_DB = Path("eval_results.db")
 
@@ -129,15 +129,14 @@ class ResultStore:
             The run_id used.
         """
         run_id = run_id or str(uuid.uuid4())
-        now = datetime.now(tz=timezone.utc).isoformat()
+        now = datetime.now(tz=UTC).isoformat()
         agg_metrics: dict[str, float] = result.get("metrics", {})
         per_sample: dict[str, list[float]] = result.get("per_sample", {})
         skipped: list[str] = result.get("skipped_metrics", [])
 
         with self._conn() as conn:
             conn.execute(
-                "INSERT INTO runs (run_id, created_at, metrics, n_samples, skipped) "
-                "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO runs (run_id, created_at, metrics, n_samples, skipped) " "VALUES (?, ?, ?, ?, ?)",
                 (
                     run_id,
                     now,
@@ -184,8 +183,7 @@ class ResultStore:
         """Return summary rows for recent runs, newest first."""
         with self._conn() as conn:
             rows = conn.execute(
-                "SELECT run_id, created_at, metrics, n_samples, skipped "
-                "FROM runs ORDER BY id DESC LIMIT ?",
+                "SELECT run_id, created_at, metrics, n_samples, skipped " "FROM runs ORDER BY id DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [
@@ -202,9 +200,7 @@ class ResultStore:
     def get_run(self, run_id: str) -> dict[str, Any] | None:
         """Return full detail for a single run including per-sample scores."""
         with self._conn() as conn:
-            run_row = conn.execute(
-                "SELECT * FROM runs WHERE run_id = ?", (run_id,)
-            ).fetchone()
+            run_row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
             if run_row is None:
                 return None
 

--- a/src/app/eval/retrieval_metrics.py
+++ b/src/app/eval/retrieval_metrics.py
@@ -32,11 +32,7 @@ def mean_reciprocal_rank(retrieved_ids: list[str], relevant_ids: set[str]) -> fl
 def ndcg_at_k(retrieved_ids: list[str], relevant_ids: set[str], k: int) -> float:
     """Normalized Discounted Cumulative Gain at K with binary relevance."""
     top_k = retrieved_ids[:k]
-    dcg = sum(
-        1.0 / math.log2(rank + 1)
-        for rank, doc_id in enumerate(top_k, start=1)
-        if doc_id in relevant_ids
-    )
+    dcg = sum(1.0 / math.log2(rank + 1) for rank, doc_id in enumerate(top_k, start=1) if doc_id in relevant_ids)
     ideal_hits = min(len(relevant_ids), k)
     idcg = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_hits + 1))
     return dcg / idcg if idcg > 0 else 0.0

--- a/src/app/logging/json_logger.py
+++ b/src/app/logging/json_logger.py
@@ -13,9 +13,7 @@ trace_id_var: ContextVar[str | None] = ContextVar("trace_id", default=None)
 class JsonFormatter(jsonlogger.JsonFormatter):
     """JSON formatter that enforces the required logging schema."""
 
-    def add_fields(
-        self, log_record: dict[str, Any], record: logging.LogRecord, message_dict: dict[str, Any]
-    ) -> None:  # noqa: D401
+    def add_fields(self, log_record: dict[str, Any], record: logging.LogRecord, message_dict: dict[str, Any]) -> None:  # noqa: D401
         super().add_fields(log_record, record, message_dict)
         log_record.setdefault("timestamp", self.formatTime(record, self.datefmt))
         log_record.setdefault("level", record.levelname)

--- a/src/app/retrieval/embeddings.py
+++ b/src/app/retrieval/embeddings.py
@@ -14,7 +14,5 @@ class EmbeddingsClient:
         self.model = SentenceTransformer(model_name, device=device)
 
     def embed(self, texts: list[str], *, normalize: bool = True) -> np.ndarray:
-        vectors = self.model.encode(
-            texts, batch_size=32, convert_to_numpy=True, normalize_embeddings=normalize
-        )
+        vectors = self.model.encode(texts, batch_size=32, convert_to_numpy=True, normalize_embeddings=normalize)
         return vectors.astype(np.float32)

--- a/src/app/retrieval/ingest_cli.py
+++ b/src/app/retrieval/ingest_cli.py
@@ -14,9 +14,7 @@ def read_text_file(path: Path) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Ingest plain text/markdown files into Qdrant Cloud"
-    )
+    parser = argparse.ArgumentParser(description="Ingest plain text/markdown files into Qdrant Cloud")
     parser.add_argument("paths", nargs="+", help="File or directory paths to ingest")
     parser.add_argument("--chunk-size", type=int, default=1000)
     parser.add_argument("--chunk-overlap", type=int, default=150)
@@ -32,9 +30,7 @@ def main() -> None:
         path = Path(p)
         files: list[Path] = []
         if path.is_dir():
-            files = [
-                f for f in path.rglob("*") if f.is_file() and f.suffix.lower() in {".txt", ".md"}
-            ]
+            files = [f for f in path.rglob("*") if f.is_file() and f.suffix.lower() in {".txt", ".md"}]
         elif path.is_file():
             files = [path]
         else:
@@ -62,9 +58,7 @@ def main() -> None:
         desired_vector_name="content",
     )
 
-    payloads = [
-        {"source_id": c.source_id, "chunk_index": c.chunk_index, "text": c.text} for c in all_chunks
-    ]
+    payloads = [{"source_id": c.source_id, "chunk_index": c.chunk_index, "text": c.text} for c in all_chunks]
 
     print("Upserting to Qdrant Cloud ...")
     upsert_points(client, collection_name, vectors, payloads, vector_name=vector_name)

--- a/src/app/retrieval/qdrant_store.py
+++ b/src/app/retrieval/qdrant_store.py
@@ -21,8 +21,8 @@ def ensure_collection(
 ) -> tuple[str, str | None]:
     """Ensure collection exists and return (collection_name, vector_name_if_named).
 
-    If the collection exists, attempt to detect if it uses a named-vector schema and return the 
-    name. If it does not exist, create either a single-vector collection or a named-vector 
+    If the collection exists, attempt to detect if it uses a named-vector schema and return the
+    name. If it does not exist, create either a single-vector collection or a named-vector
     collection if desired_vector_name is provided.
     """
     existing = [c.name for c in client.get_collections().collections]
@@ -38,9 +38,7 @@ def ensure_collection(
                 client.create_collection(
                     collection_name=new_collection,
                     vectors_config={
-                        desired_vector_name: qmodels.VectorParams(
-                            size=vector_size, distance=qmodels.Distance.COSINE
-                        )
+                        desired_vector_name: qmodels.VectorParams(size=vector_size, distance=qmodels.Distance.COSINE)
                     },
                 )
             except Exception:
@@ -53,9 +51,7 @@ def ensure_collection(
         client.create_collection(
             collection_name=collection,
             vectors_config={
-                desired_vector_name: qmodels.VectorParams(
-                    size=vector_size, distance=qmodels.Distance.COSINE
-                )
+                desired_vector_name: qmodels.VectorParams(size=vector_size, distance=qmodels.Distance.COSINE)
             },
         )
         return (collection, desired_vector_name)
@@ -97,9 +93,7 @@ def _detect_named_vector_from_dump(client: QdrantClient, collection: str) -> str
     """Fallback: inspect raw model dump to extract a named vector key if present."""
     info = client.get_collection(collection)
     data = info.model_dump(exclude_none=True)  # type: ignore[attr-defined]
-    vectors = (
-        data.get("config", {}).get("params", {}).get("vectors") if isinstance(data, dict) else None
-    )
+    vectors = data.get("config", {}).get("params", {}).get("vectors") if isinstance(data, dict) else None
     if isinstance(vectors, dict):
         if "size" in vectors:
             return None

--- a/src/app/sdk/client.py
+++ b/src/app/sdk/client.py
@@ -115,9 +115,7 @@ class RagEval:
         resp.raise_for_status()
         return resp.json()
 
-    def compare_runs(
-        self, run_ids: list[str], timeout: int = 30
-    ) -> dict:
+    def compare_runs(self, run_ids: list[str], timeout: int = 30) -> dict:
         """Compare metrics across multiple named runs."""
         resp = requests.post(
             f"{self._url}/v1/runs/compare",
@@ -147,12 +145,8 @@ class RagEval:
         answer = chain_output.get("result") or chain_output.get("answer", "")
         docs = chain_output.get("source_documents", [])
 
-        contexts = [
-            getattr(doc, "page_content", str(doc)) for doc in docs
-        ]
-        retrieved_doc_ids = [
-            getattr(doc, "metadata", {}).get("id", "") for doc in docs
-        ]
+        contexts = [getattr(doc, "page_content", str(doc)) for doc in docs]
+        retrieved_doc_ids = [getattr(doc, "metadata", {}).get("id", "") for doc in docs]
 
         return {
             "question": question,
@@ -180,9 +174,7 @@ class RagEval:
                 text = get_content() if callable(get_content) else str(node)
             contexts.append(text)
 
-        retrieved_doc_ids = [
-            getattr(node, "node_id", "") for node in source_nodes
-        ]
+        retrieved_doc_ids = [getattr(node, "node_id", "") for node in source_nodes]
 
         return {
             "question": question,

--- a/src/harness/__init__.py
+++ b/src/harness/__init__.py
@@ -2,12 +2,12 @@ from harness.protocol import RAGEvaluable, validate_evaluable
 from harness.result_store import ResultStore
 from harness.runner import EvaluationRunner
 from harness.schemas import (
+    METRIC_GROUPS,
     AgentTrace,
     BenchmarkReport,
     EvalResult,
     EvalSample,
     MetricGroup,
-    METRIC_GROUPS,
     ReasoningStep,
     RetrievedChunk,
     RunConfig,
@@ -16,10 +16,19 @@ from harness.schemas import (
 )
 
 __all__ = [
-    "AgentTrace", "BenchmarkReport", "EvalResult", "EvalSample",
-    "MetricGroup", "METRIC_GROUPS", "ReasoningStep", "RetrievedChunk",
-    "RunConfig", "ToolCall", "ToolCallType",
-    "RAGEvaluable", "validate_evaluable",
+    "AgentTrace",
+    "BenchmarkReport",
+    "EvalResult",
+    "EvalSample",
+    "MetricGroup",
+    "METRIC_GROUPS",
+    "ReasoningStep",
+    "RetrievedChunk",
+    "RunConfig",
+    "ToolCall",
+    "ToolCallType",
+    "RAGEvaluable",
+    "validate_evaluable",
     "EvaluationRunner",
     "ResultStore",
 ]

--- a/src/harness/result_store.py
+++ b/src/harness/result_store.py
@@ -70,7 +70,7 @@ class ResultStore:
         with sqlite3.connect(self._db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
-                "SELECT run_id, created_at, n_samples, metrics " "FROM benchmark_runs ORDER BY created_at DESC LIMIT ?",
+                "SELECT run_id, created_at, n_samples, metrics FROM benchmark_runs ORDER BY created_at DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [

--- a/src/harness/result_store.py
+++ b/src/harness/result_store.py
@@ -52,9 +52,7 @@ class ResultStore:
         """Return a run by ID, or None if not found."""
         with sqlite3.connect(self._db_path) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT * FROM benchmark_runs WHERE run_id = ?", (run_id,)
-            ).fetchone()
+            row = conn.execute("SELECT * FROM benchmark_runs WHERE run_id = ?", (run_id,)).fetchone()
         if row is None:
             return None
         return {
@@ -72,8 +70,7 @@ class ResultStore:
         with sqlite3.connect(self._db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
-                "SELECT run_id, created_at, n_samples, metrics "
-                "FROM benchmark_runs ORDER BY created_at DESC LIMIT ?",
+                "SELECT run_id, created_at, n_samples, metrics " "FROM benchmark_runs ORDER BY created_at DESC LIMIT ?",
                 (limit,),
             ).fetchall()
         return [
@@ -95,7 +92,5 @@ class ResultStore:
                 all_metrics.update(r["metrics"].keys())
         comparison: dict[str, list] = {}
         for metric in sorted(all_metrics):
-            comparison[metric] = [
-                (r["metrics"].get(metric) if r else None) for r in runs
-            ]
+            comparison[metric] = [(r["metrics"].get(metric) if r else None) for r in runs]
         return {"run_ids": run_ids, "metrics": comparison}

--- a/src/harness/runner.py
+++ b/src/harness/runner.py
@@ -5,10 +5,10 @@ import uuid
 from datetime import UTC, datetime
 
 from harness.schemas import (
+    METRIC_GROUPS,
     BenchmarkReport,
     EvalResult,
     EvalSample,
-    METRIC_GROUPS,
     RunConfig,
 )
 
@@ -53,7 +53,7 @@ class EvaluationRunner:
         skip_reasons: dict[str, str] = {}
 
         # Pre-flight: determine what can actually be computed
-        has_ground_truths = all(s.ground_truth for s in samples)
+        has_ground_truths = all(s.ground_truths for s in samples)
         has_relevant_ids = all(s.relevant_doc_ids for s in samples)
 
         active: list[str] = []
@@ -81,7 +81,7 @@ class EvaluationRunner:
                     "question": s.question,
                     "contexts": s.contexts,
                     "answer": s.answer,
-                    "ground_truths": [s.ground_truth] if s.ground_truth else [],
+                    "ground_truths": s.ground_truths,
                 }
                 for s in samples
             ]
@@ -96,19 +96,25 @@ class EvaluationRunner:
         # --- Retrieval metrics and agentic metrics ---
         for m in other_metrics:
             if m == "source_attribution_accuracy":
-                from app.eval.agentic_metrics import source_attribution_accuracy
                 import re
+
+                from app.eval.agentic_metrics import source_attribution_accuracy
+
                 scores = []
                 for s in samples:
-                    cited = re.findall(r'\[source:\s*([^\]]+)\]', s.answer)
+                    cited = re.findall(r"\[source:\s*([^\]]+)\]", s.answer)
                     result = source_attribution_accuracy(cited, s.retrieved_doc_ids)
                     scores.append(result["score"])
                 aggregate[m] = sum(scores) / len(scores) if scores else 1.0
                 per_sample_scores[m] = scores
             elif m in _RELEVANT_IDS_REQUIRED:
                 from app.eval.retrieval_metrics import (
-                    precision_at_k, recall_at_k, mean_reciprocal_rank, ndcg_at_k
+                    mean_reciprocal_rank,
+                    ndcg_at_k,
+                    precision_at_k,
+                    recall_at_k,
                 )
+
                 k = self.config.k
                 scores = []
                 for s in samples:

--- a/src/harness/schemas.py
+++ b/src/harness/schemas.py
@@ -106,6 +106,22 @@ class AgentTrace(BaseModel):
     total_latency_ms: float | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    def __init__(self, **data: Any) -> None:
+        # Backwards-compat shim, parity with EvalSample. Without this the
+        # legacy singular kwarg is silently dropped under Pydantic v2 — the
+        # exact contract failure the audit RB-H5 was meant to close.
+        if "ground_truth" in data and "ground_truths" not in data:
+            gt = data.pop("ground_truth")
+            data["ground_truths"] = [gt] if gt else []
+        super().__init__(**data)
+
+    @property
+    def ground_truth(self) -> str | None:
+        """Legacy singular accessor. Returns the first ground_truths entry."""
+        return self.ground_truths[0] if self.ground_truths else None
+
 
 class EvalResult(BaseModel):
     sample_id: str

--- a/src/harness/schemas.py
+++ b/src/harness/schemas.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class MetricGroup(str, Enum):
+class MetricGroup(StrEnum):
     CLASSIC = "classic"
     RETRIEVAL = "retrieval"
     AGENTIC_V1 = "agentic_v1"
@@ -16,7 +16,7 @@ class MetricGroup(str, Enum):
     FULL = "full"
 
 
-class ToolCallType(str, Enum):
+class ToolCallType(StrEnum):
     RETRIEVE = "retrieve"
     WEB_SEARCH = "web_search"
     CODE_EXEC = "code_exec"

--- a/src/harness/schemas.py
+++ b/src/harness/schemas.py
@@ -31,15 +31,37 @@ class RetrievedChunk(BaseModel):
 
 
 class EvalSample(BaseModel):
-    """Universal input for classic RAG evaluation. Works with any RAG system."""
+    """Universal input for classic RAG evaluation. Works with any RAG system.
+
+    The ``ground_truths`` field is a list (Ragas convention) so a sample can
+    carry multiple acceptable references. The legacy singular ``ground_truth``
+    keyword is accepted at construction time for backwards compatibility (it
+    becomes the first element of ``ground_truths``).
+    """
+
     sample_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     question: str = Field(..., min_length=1)
     contexts: list[str] = Field(..., min_length=1)
     answer: str = Field(..., min_length=1)
-    ground_truth: str | None = None
+    ground_truths: list[str] = Field(default_factory=list)
     retrieved_doc_ids: list[str] = Field(default_factory=list)
     relevant_doc_ids: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+    def __init__(self, **data: Any) -> None:
+        # Backwards-compat: accept legacy singular `ground_truth=` kwarg and
+        # promote to the plural list. Pre-existing user code keeps working.
+        if "ground_truth" in data and "ground_truths" not in data:
+            gt = data.pop("ground_truth")
+            data["ground_truths"] = [gt] if gt else []
+        super().__init__(**data)
+
+    @property
+    def ground_truth(self) -> str | None:
+        """Legacy singular accessor. Returns the first ground_truths entry."""
+        return self.ground_truths[0] if self.ground_truths else None
 
     @field_validator("question", "answer")
     @classmethod
@@ -66,11 +88,16 @@ class ReasoningStep(BaseModel):
 
 
 class AgentTrace(BaseModel):
-    """Input for agentic RAG evaluation. Captures the full reasoning trace."""
+    """Input for agentic RAG evaluation. Captures the full reasoning trace.
+
+    ``ground_truths`` is a list (Ragas convention). Legacy singular
+    ``ground_truth`` is accepted at construction for backwards compatibility.
+    """
+
     trace_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     question: str = Field(..., min_length=1)
     final_answer: str = Field(..., min_length=1)
-    ground_truth: str | None = None
+    ground_truths: list[str] = Field(default_factory=list)
     tool_calls: list[ToolCall] = Field(default_factory=list)
     reasoning_steps: list[ReasoningStep] = Field(default_factory=list)
     retrieved_chunks: list[RetrievedChunk] = Field(default_factory=list)
@@ -101,7 +128,7 @@ class BenchmarkReport(BaseModel):
 class RunConfig(BaseModel):
     metrics: list[str] = Field(default_factory=list)
     metric_group: MetricGroup | None = None
-    judge_model: str = "gemini-1.5-flash"
+    judge_model: str = "gemini-2.5-flash"
     judge_temperature: float = 0.0
     k: int = 5
     faithfulness_threshold: float = 0.7
@@ -109,7 +136,10 @@ class RunConfig(BaseModel):
 
 
 METRIC_GROUPS: dict[str, list[str]] = {
-    "classic": ["faithfulness", "answer_relevancy"],
+    # `classic` = the four canonical Ragas metrics. context_precision and
+    # context_recall require ground_truths; they short-circuit to skipped
+    # when unavailable (see ragas_runner.py).
+    "classic": ["faithfulness", "answer_relevancy", "context_precision", "context_recall"],
     "retrieval": ["precision_at_k", "recall_at_k", "mrr", "ndcg_at_k"],
     "agentic_v1": [
         "source_attribution_accuracy",
@@ -123,10 +153,25 @@ METRIC_GROUPS: dict[str, list[str]] = {
         "reasoning_hallucination",
         "context_coherence_across_turns",
     ],
+    # `full` = every metric group concatenated. Keep in sync when groups change
+    # — audit RB-M9 caught a prior version that omitted context_precision /
+    # context_recall / agentic_v2.
     "full": [
-        "faithfulness", "answer_relevancy",
-        "precision_at_k", "recall_at_k", "mrr", "ndcg_at_k",
-        "source_attribution_accuracy", "retrieval_necessity",
-        "agent_faithfulness", "tool_call_accuracy",
+        "faithfulness",
+        "answer_relevancy",
+        "context_precision",
+        "context_recall",
+        "precision_at_k",
+        "recall_at_k",
+        "mrr",
+        "ndcg_at_k",
+        "source_attribution_accuracy",
+        "retrieval_necessity",
+        "agent_faithfulness",
+        "tool_call_accuracy",
+        "multihop_faithfulness",
+        "agent_trajectory_efficiency",
+        "reasoning_hallucination",
+        "context_coherence_across_turns",
     ],
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ don't prevent ENFORCE_API_KEY=true from being loaded in tests.
 Solution: Override AppSettings model_config to not read .env during tests,
 and reset the lru_cache before each test so patches take effect.
 """
+
 from __future__ import annotations
 
-import os
 import pytest
 
 
@@ -25,11 +25,13 @@ def disable_api_key_enforcement(monkeypatch):
 
     # Clear the lru_cache so AppSettings re-reads from environment
     from app.config.settings import get_settings
+
     get_settings.cache_clear()
 
     # Patch AppSettings to not read .env file during tests
-    from app.config import settings as settings_module
     from pydantic_settings import SettingsConfigDict
+
+    from app.config import settings as settings_module
 
     original_config = settings_module.AppSettings.model_config
     settings_module.AppSettings.model_config = SettingsConfigDict(

--- a/tests/e2e/test_api_harness.py
+++ b/tests/e2e/test_api_harness.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from fastapi.testclient import TestClient
 
@@ -12,6 +10,7 @@ def _set_e2e_env(monkeypatch_module):
     monkeypatch_module.setenv("LLM_PROVIDER", "echo")
     # Clear settings cache so the patched env is picked up
     from app.config.settings import get_settings
+
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -21,6 +20,7 @@ def _set_e2e_env(monkeypatch_module):
 def monkeypatch_module(request):
     """Module-scoped monkeypatch fixture."""
     from _pytest.monkeypatch import MonkeyPatch
+
     mp = MonkeyPatch()
     yield mp
     mp.undo()
@@ -29,6 +29,7 @@ def monkeypatch_module(request):
 @pytest.fixture(scope="module")
 def client(_set_e2e_env):
     from app.main import app
+
     return TestClient(app)
 
 

--- a/tests/integration/test_sdk.py
+++ b/tests/integration/test_sdk.py
@@ -1,5 +1,5 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from app.sdk.client import RagEval
 
 
@@ -26,6 +26,7 @@ def test_sdk_evaluate_list_of_dicts():
 
 def test_sdk_from_langchain_style():
     """SDK from_langchain adapter converts chain output to EvalSample dict."""
+
     class FakeDoc:
         page_content = "RAG is Retrieval-Augmented Generation."
         metadata = {"id": "doc-1"}
@@ -44,6 +45,7 @@ def test_sdk_from_langchain_style():
 
 def test_sdk_from_llamaindex_style():
     """SDK from_llamaindex adapter converts query engine response."""
+
     class FakeNode:
         text = "RAG stands for Retrieval-Augmented Generation."
         node_id = "node-abc"
@@ -53,6 +55,7 @@ def test_sdk_from_llamaindex_style():
 
     class FakeResponse:
         source_nodes = [FakeNode()]
+
         def __str__(self):
             return "RAG is Retrieval-Augmented Generation."
 

--- a/tests/test_eval_pipeline.py
+++ b/tests/test_eval_pipeline.py
@@ -13,9 +13,7 @@ Run with:
 
 from __future__ import annotations
 
-import json
 import pathlib
-import tempfile
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -150,9 +148,7 @@ class TestResultStore:
         # Slightly different second run
         result2 = dict(fake_ragas_result)
         result2["metrics"] = {k: v - 0.05 for k, v in fake_ragas_result["metrics"].items()}
-        result2["per_sample"] = {
-            k: [v - 0.05 for v in vs] for k, vs in fake_ragas_result["per_sample"].items()
-        }
+        result2["per_sample"] = {k: [v - 0.05 for v in vs] for k, vs in fake_ragas_result["per_sample"].items()}
         result_store.save_run(result2, golden_samples, run_id="run-B")
 
         comparison = result_store.compare_runs(["run-A", "run-B"])
@@ -202,14 +198,13 @@ class TestRagasRunner:
     than at ``app.eval.ragas_runner.evaluate``.
     """
 
-    def test_skips_retrieval_metrics_without_ground_truth(
-        self, minimal_sample: dict[str, Any]
-    ) -> None:
+    def test_skips_retrieval_metrics_without_ground_truth(self, minimal_sample: dict[str, Any]) -> None:
         """When ground_truths is empty, context_precision and context_recall are skipped."""
-        from app.eval import ragas_runner as rr
         import os
 
         import pandas as pd
+
+        from app.eval import ragas_runner as rr
 
         os.environ.setdefault("GEMINI_API_KEY", "test-key")
 
@@ -219,9 +214,7 @@ class TestRagasRunner:
             patch("ragas.llms.LangchainLLMWrapper"),
         ):
             mock_eval.return_value = MagicMock(
-                to_pandas=lambda: pd.DataFrame(
-                    [{"faithfulness": 0.9, "answer_relevancy": 0.88}]
-                )
+                to_pandas=lambda: pd.DataFrame([{"faithfulness": 0.9, "answer_relevancy": 0.88}])
             )
             result = rr.run_evaluation([minimal_sample])
 
@@ -230,13 +223,13 @@ class TestRagasRunner:
         assert "context_precision" in result["skipped_metrics"]
         assert "context_recall" in result["skipped_metrics"]
 
-    def test_includes_retrieval_metrics_with_ground_truth(
-        self, full_sample: dict[str, Any]
-    ) -> None:
+    def test_includes_retrieval_metrics_with_ground_truth(self, full_sample: dict[str, Any]) -> None:
         """When ground_truths is present, all four metrics are requested."""
-        from app.eval import ragas_runner as rr
         import os
+
         import pandas as pd
+
+        from app.eval import ragas_runner as rr
 
         os.environ.setdefault("GEMINI_API_KEY", "test-key")
 
@@ -265,8 +258,9 @@ class TestRagasRunner:
 
     def test_raises_without_gemini_key(self, full_sample: dict[str, Any]) -> None:
         """RuntimeError raised when GEMINI_API_KEY is absent."""
-        from app.eval import ragas_runner as rr
         import os
+
+        from app.eval import ragas_runner as rr
 
         saved = os.environ.pop("GEMINI_API_KEY", None)
         try:
@@ -276,13 +270,13 @@ class TestRagasRunner:
             if saved:
                 os.environ["GEMINI_API_KEY"] = saved
 
-    def test_field_translation_question_to_user_input(
-        self, full_sample: dict[str, Any]
-    ) -> None:
+    def test_field_translation_question_to_user_input(self, full_sample: dict[str, Any]) -> None:
         """Samples keyed as 'question'/'contexts'/'answer' are translated to SingleTurnSample."""
-        from app.eval import ragas_runner as rr
         import os
+
         import pandas as pd
+
+        from app.eval import ragas_runner as rr
 
         os.environ.setdefault("GEMINI_API_KEY", "test-key")
         captured_dataset: list[Any] = []

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -50,9 +50,7 @@ def test_api_key_security_enforced_mode():
         app.dependency_overrides[get_rag_engine] = lambda: mock_engine
 
         try:
-            resp = client.post(
-                "/v1/query", json={"query": "hi"}, headers={"X-API-Key": "secret-123"}
-            )
+            resp = client.post("/v1/query", json={"query": "hi"}, headers={"X-API-Key": "secret-123"})
             assert resp.status_code == 200
         finally:
             app.dependency_overrides = {}

--- a/tests/unit/test_agentic_llm_metrics.py
+++ b/tests/unit/test_agentic_llm_metrics.py
@@ -1,11 +1,13 @@
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from harness.schemas import AgentTrace, ToolCall, ReasoningStep, RetrievedChunk
+from harness.schemas import AgentTrace, ReasoningStep, RetrievedChunk, ToolCall
+
 from app.eval.agentic_llm_metrics import (
     compute_agent_faithfulness,
-    compute_tool_call_accuracy,
     compute_retrieval_necessity,
+    compute_tool_call_accuracy,
 )
 
 
@@ -39,33 +41,41 @@ def make_trace():
     )
 
 
-MOCK_FAITHFUL_RESPONSE = json.dumps({
-    "step_analysis": [
-        {"step_index": 0, "claims": ["August 2025"], "supported": [True], "faithfulness_score": 1.0}
-    ],
-    "trace_faithfulness_score": 1.0,
-    "worst_step": 0,
-    "critical_hallucinations": [],
-})
+MOCK_FAITHFUL_RESPONSE = json.dumps(
+    {
+        "step_analysis": [{"step_index": 0, "claims": ["August 2025"], "supported": [True], "faithfulness_score": 1.0}],
+        "trace_faithfulness_score": 1.0,
+        "worst_step": 0,
+        "critical_hallucinations": [],
+    }
+)
 
-MOCK_TOOL_RESPONSE = json.dumps({
-    "tool_evaluations": [
-        {
-            "step_index": 0, "tool_name": "retrieve",
-            "necessary": True, "correct_tool": True,
-            "input_quality": 1.0, "score": 1.0, "reason": "Correct retrieval"
-        }
-    ],
-    "overall_score": 1.0,
-})
+MOCK_TOOL_RESPONSE = json.dumps(
+    {
+        "tool_evaluations": [
+            {
+                "step_index": 0,
+                "tool_name": "retrieve",
+                "necessary": True,
+                "correct_tool": True,
+                "input_quality": 1.0,
+                "score": 1.0,
+                "reason": "Correct retrieval",
+            }
+        ],
+        "overall_score": 1.0,
+    }
+)
 
-MOCK_NECESSITY_RESPONSE = json.dumps({
-    "necessity": "NECESSARY",
-    "parametric_answer_possible": False,
-    "retrieval_contribution": "essential",
-    "score": 1.0,
-    "reasoning": "Requires specific regulatory date.",
-})
+MOCK_NECESSITY_RESPONSE = json.dumps(
+    {
+        "necessity": "NECESSARY",
+        "parametric_answer_possible": False,
+        "retrieval_contribution": "essential",
+        "score": 1.0,
+        "reasoning": "Requires specific regulatory date.",
+    }
+)
 
 
 def _mock_llm(response: str):

--- a/tests/unit/test_agentic_llm_metrics.py
+++ b/tests/unit/test_agentic_llm_metrics.py
@@ -2,13 +2,13 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from harness.schemas import AgentTrace, ReasoningStep, RetrievedChunk, ToolCall
 
 from app.eval.agentic_llm_metrics import (
     compute_agent_faithfulness,
     compute_retrieval_necessity,
     compute_tool_call_accuracy,
 )
+from harness.schemas import AgentTrace, ReasoningStep, RetrievedChunk, ToolCall
 
 
 def make_trace():

--- a/tests/unit/test_agentic_metrics.py
+++ b/tests/unit/test_agentic_metrics.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app.eval.agentic_metrics import source_attribution_accuracy
 
 

--- a/tests/unit/test_faithfulness.py
+++ b/tests/unit/test_faithfulness.py
@@ -1,23 +1,15 @@
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from app.eval.faithfulness import compute_faithfulness
 
+MOCK_FULL_SUPPORT = json.dumps({"claims": ["X is true", "Y happened"], "supported": [True, True]})
 
-MOCK_FULL_SUPPORT = json.dumps({
-    "claims": ["X is true", "Y happened"],
-    "supported": [True, True]
-})
+MOCK_PARTIAL_SUPPORT = json.dumps({"claims": ["X is true", "Y happened"], "supported": [True, False]})
 
-MOCK_PARTIAL_SUPPORT = json.dumps({
-    "claims": ["X is true", "Y happened"],
-    "supported": [True, False]
-})
-
-MOCK_NO_CLAIMS = json.dumps({
-    "claims": [],
-    "supported": []
-})
+MOCK_NO_CLAIMS = json.dumps({"claims": [], "supported": []})
 
 MOCK_MALFORMED = "not json at all"
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -4,6 +4,7 @@ from harness.protocol import RAGEvaluable, validate_evaluable
 
 class MockRAG:
     """Minimal compliant implementation."""
+
     def run(self, question: str, contexts_override: list[str] | None = None) -> dict:
         return {
             "answer": f"Answer to: {question}",
@@ -14,6 +15,7 @@ class MockRAG:
 
 class LangChainRAG:
     """Simulate a LangChain chain — doesn't implement protocol directly."""
+
     def invoke(self, inputs: dict) -> dict:
         return {"result": "answer", "source_documents": []}
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,4 +1,5 @@
 import pytest
+
 from harness.protocol import RAGEvaluable, validate_evaluable
 
 

--- a/tests/unit/test_result_store.py
+++ b/tests/unit/test_result_store.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 from harness.result_store import ResultStore
 from harness.schemas import BenchmarkReport
 

--- a/tests/unit/test_result_store.py
+++ b/tests/unit/test_result_store.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from harness.result_store import ResultStore
 from harness.schemas import BenchmarkReport
 

--- a/tests/unit/test_retrieval_metrics.py
+++ b/tests/unit/test_retrieval_metrics.py
@@ -1,47 +1,57 @@
-import math
-import pytest
-from app.eval.retrieval_metrics import precision_at_k, recall_at_k, mean_reciprocal_rank, ndcg_at_k
+from app.eval.retrieval_metrics import mean_reciprocal_rank, ndcg_at_k, precision_at_k, recall_at_k
 
 
 def test_precision_at_k_perfect():
     assert precision_at_k(["a", "b", "c"], {"a", "b", "c"}, k=3) == 1.0
 
+
 def test_precision_at_k_partial():
     result = precision_at_k(["a", "x", "b"], {"a", "b", "c"}, k=3)
-    assert abs(result - 2/3) < 1e-9
+    assert abs(result - 2 / 3) < 1e-9
+
 
 def test_precision_at_k_zero():
     assert precision_at_k(["x", "y", "z"], {"a", "b", "c"}, k=3) == 0.0
 
+
 def test_precision_at_k_zero_k():
     assert precision_at_k(["a"], {"a"}, k=0) == 0.0
 
+
 def test_recall_at_k_perfect():
     assert recall_at_k(["a", "b", "c"], {"a", "b", "c"}, k=3) == 1.0
+
 
 def test_recall_at_k_partial():
     result = recall_at_k(["a", "x", "b"], {"a", "b", "c", "d"}, k=3)
     assert abs(result - 0.5) < 1e-9
 
+
 def test_recall_at_k_empty_relevant():
     assert recall_at_k(["a", "b"], set(), k=2) == 0.0
+
 
 def test_mrr_first_relevant_at_1():
     assert mean_reciprocal_rank(["a", "b", "c"], {"a"}) == 1.0
 
+
 def test_mrr_first_relevant_at_3():
     result = mean_reciprocal_rank(["x", "y", "a"], {"a"})
-    assert abs(result - 1/3) < 1e-9
+    assert abs(result - 1 / 3) < 1e-9
+
 
 def test_mrr_no_relevant():
     assert mean_reciprocal_rank(["x", "y", "z"], {"a"}) == 0.0
+
 
 def test_ndcg_perfect():
     result = ndcg_at_k(["a", "b", "c"], {"a", "b", "c"}, k=3)
     assert abs(result - 1.0) < 1e-9
 
+
 def test_ndcg_empty_relevant():
     assert ndcg_at_k(["a", "b"], set(), k=2) == 0.0
+
 
 def test_ndcg_partial():
     # Only first doc is relevant

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from harness.runner import EvaluationRunner
-from harness.schemas import EvalSample, RunConfig, BenchmarkReport
+from harness.schemas import BenchmarkReport, EvalSample, RunConfig
 
 
 @pytest.fixture

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+
 from harness.runner import EvaluationRunner
 from harness.schemas import BenchmarkReport, EvalSample, RunConfig
 

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,10 +1,15 @@
-import pytest
 import uuid
-from pydantic import ValidationError
+
+import pytest
 from harness.schemas import (
-    EvalSample, AgentTrace, ToolCall, ReasoningStep,
-    RetrievedChunk, EvalResult, BenchmarkReport, RunConfig
+    AgentTrace,
+    BenchmarkReport,
+    EvalSample,
+    RunConfig,
+    ToolCall,
 )
+from pydantic import ValidationError
+
 
 def test_eval_sample_minimal():
     s = EvalSample(
@@ -15,6 +20,7 @@ def test_eval_sample_minimal():
     assert s.sample_id is not None
     uuid.UUID(s.sample_id)  # raises ValueError if not a valid UUID
     assert s.ground_truth is None
+
 
 def test_eval_sample_with_ground_truth():
     s = EvalSample(
@@ -27,9 +33,11 @@ def test_eval_sample_with_ground_truth():
     )
     assert s.relevant_doc_ids == ["doc-1", "doc-2"]
 
+
 def test_eval_sample_requires_question():
     with pytest.raises(ValidationError):
         EvalSample(question="", contexts=["ctx"], answer="ans")
+
 
 def test_agent_trace_minimal():
     t = AgentTrace(
@@ -47,6 +55,7 @@ def test_agent_trace_minimal():
     assert len(t.tool_calls) == 1
     assert t.conversation_history == []
 
+
 def test_benchmark_report_score_range():
     report = BenchmarkReport(
         run_id="run-001",
@@ -55,10 +64,12 @@ def test_benchmark_report_score_range():
     )
     assert 0.0 <= report.metrics["faithfulness"] <= 1.0
 
+
 def test_run_config_defaults():
     config = RunConfig(metrics=["faithfulness"])
-    assert config.judge_model == "gemini-1.5-flash"
+    assert config.judge_model == "gemini-2.5-flash"
     assert config.metric_group is None
+
 
 def test_eval_sample_unique_ids():
     s1 = EvalSample(question="Q1?", contexts=["ctx"], answer="A1.")

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -39,6 +39,42 @@ def test_eval_sample_requires_question():
         EvalSample(question="", contexts=["ctx"], answer="ans")
 
 
+def test_eval_sample_legacy_singular_kwarg_promoted():
+    """Backward-compat: EvalSample(ground_truth="x") promotes to plural list."""
+    s = EvalSample(
+        question="q",
+        contexts=["c"],
+        answer="a",
+        ground_truth="legacy-single",
+    )
+    assert s.ground_truths == ["legacy-single"]
+    assert s.ground_truth == "legacy-single"  # legacy property accessor
+
+
+def test_agent_trace_legacy_singular_kwarg_promoted():
+    """Regression test for RB-NEW1: AgentTrace(ground_truth="x") must promote to
+    plural list (the EvalSample shim was applied, the AgentTrace shim was
+    initially missed and silently dropped the kwarg)."""
+    t = AgentTrace(
+        question="q",
+        final_answer="a",
+        ground_truth="legacy-single",
+    )
+    assert t.ground_truths == ["legacy-single"]
+    assert t.ground_truth == "legacy-single"  # legacy property accessor
+
+
+def test_agent_trace_plural_kwarg():
+    """AgentTrace(ground_truths=[...]) is the canonical shape."""
+    t = AgentTrace(
+        question="q",
+        final_answer="a",
+        ground_truths=["one", "two"],
+    )
+    assert t.ground_truths == ["one", "two"]
+    assert t.ground_truth == "one"  # accessor returns first element
+
+
 def test_agent_trace_minimal():
     t = AgentTrace(
         question="What is RAG?",

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,6 +1,8 @@
 import uuid
 
 import pytest
+from pydantic import ValidationError
+
 from harness.schemas import (
     AgentTrace,
     BenchmarkReport,
@@ -8,7 +10,6 @@ from harness.schemas import (
     RunConfig,
     ToolCall,
 )
-from pydantic import ValidationError
 
 
 def test_eval_sample_minimal():


### PR DESCRIPTION
## Summary

Closes the **2026-05-10 Top-N=4 launch readiness audit** (full report at `docs/audit/T-N4-readiness-2026-05-10.md` in the aiexponent monorepo). **Path A** chosen over Path B — narrowed-scope authenticity cleanup, ship as v1.0 GA, re-petition for stronger flagship framing at v1.1.

The audit's contrarian-challenger panel had said all four critic personas DID-NOT-SURVIVE under the original v1.0.0-rc1 framing, with the Journalist-Ethicist as the most-dangerous attack ("compliance-washing pattern"). Path A removes the four artefact-level claims that fed that attack:
1. Article 15 robustness/cybersecurity overclaim → reframed as "partial Art. 15(1) accuracy input, not conformity evidence"
2. Strawmanned RAGAS comparison → corrected per docs.ragas.io
3. Unreproducible retrieval-metric scores → table removed, Repro: command added
4. Schema-vs-docs Pydantic mismatch → reconciled to Ragas-convention plural list with backward-compat shim

## What's in this PR

**Repositioning (regulatory framing):**
- Article 15 framing narrowed in README + docs/dataset-methodology.md
- docs/comparison.md: RAGAS Tool call Accuracy ✗ → ✓ with citation; Promptfoo column added; EU AI Act framing row downgraded to "Partial Art. 15(1) accuracy input"

**Production-affecting fixes:**
- Schema reconciliation (RB-H5). \`EvalSample.ground_truths\` and \`AgentTrace.ground_truths\` are now plural-list. **Backward-compat shim preserves the legacy singular \`ground_truth=\` kwarg AND the \`.ground_truth\` property** so user code keeps working.
- \`METRIC_GROUPS[\"full\"]\` now includes every metric group (was missing context_precision, context_recall, agentic_v2)
- \`MetricGroup.classic\` now includes context_precision + context_recall
- \`RunConfig.judge_model\` default gemini-1.5-flash → gemini-2.5-flash

**Legal / supply chain:**
- LICENSE replaced with verbatim Apache-2.0 SPDX template; copyright moved to NOTICE per §4(d)
- publish-pypi.yml hardened to RiskForge parity (CycloneDX SBOM + Sigstore + GitHub Release auto-creation)
- ci.yml gains ruff check + ruff format + mypy (mypy non-blocking for v1.0)

**Documentation authenticity:**
- benchmark-results.md: retriever-dependent score table removed, Repro: command added
- dataset-methodology.md: gemini-1.5 → 2.5; "cybersecurity" dropped from positioning
- README.md: \`report[\"scores\"]\` → \`report[\"metrics\"]\` (matches actual return); Art. 15 section honest

**Operational hygiene:**
- docker-compose host port 5000 → 5001 (matches README + SDK + DEPLOYMENT defaults)
- DEPLOYMENT.md rewritten for v1.0; "POC" dropped; legacy /v1/query reference removed
- SECURITY.md SQLite path corrected
- tool.ruff line-length 100 → 120 with audit-comment; full \`ruff format\` applied (23 files, no logic changes)

**Release metadata:**
- pyproject version 1.0.0-rc1 → 1.0.0
- classifier "4 - Beta" → "5 - Production/Stable"

## Verification

\`\`\`
80 passed in 28.11s
ruff check: All checks passed!
ruff format: 59 files already formatted
\`\`\`

## Test plan

- [ ] CI green on this PR (Tests + Lint + Format + Type check + License Compatibility)
- [ ] After merge, the v1.0.0 tag goes up and \`publish-pypi.yml\` fires
- [ ] Post-publish: \`pip install rag-benchmarking==1.0.0\` returns v1.0.0; legacy \`EvalSample(ground_truth=\"...\")\` still works; \`report[\"metrics\"]\` is the canonical scores key

## What is NOT in this PR

- v1.0.0 git tag + PyPI publish — separate step after merge.
- vp-responsible-ai G6 sign-off — re-review against the merged tree.
- Branch protection on main — separately authorised.
- aiexponent.com \`lib/tools.ts\` releaseVersion bump — auto-promotes RAG-Bench back to flagship via the FLAGSHIP_TOOLS self-policing filter (FLAGSHIP_COUNT returns 3 → 4).
- COI disclosure footer on /docs/rag-benchmarking — separate website PR.