### PR TITLE
release: v1.0.1 — close the three non-blocking items from the v1.0.0 sign-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-10
+
+Cleanup release. Closes the three non-blocking items the v1.0.0 sign-off
+round flagged (`docs/audit/T-N4-readiness-2026-05-10.md` §11.3 G6-A, G6-B
+and §11.1 RB-NEW3) before they accrue into a larger release. Same-day as
+v1.0.0 because the items are mechanical.
+
+### ⚠️ Breaking change (one)
+
+- **`/v1/evaluate/agent` response payload key renamed `scores` → `metrics`.**
+  This brings the agent endpoint into shape-parity with `/v1/evaluate`
+  (which has always emitted `metrics`). The RB-NEW3 sibling-endpoint
+  contract drift caught in the v1.0.0 Authenticity Shield re-review was
+  deferred to v1.0.1 with the explicit promise of a loud CHANGELOG note;
+  this is that note. **Migration:** if your code reads `r["scores"]`
+  from the agent endpoint, change it to `r["metrics"]`. The shape of
+  the inner dict (per-metric score floats) is unchanged.
+
+  Affected callers known at release time:
+  - `tests/integration/test_sdk.py` — fixed in this release
+  - `tests/e2e/test_api_harness.py` — fixed in this release
+  - `docs/ci-cd-guide.md` examples — fixed in this release
+  - `src/app/sdk/client.py` module docstring example — fixed in this release
+
+### Changed
+
+- **G6-A (SDK docstring):** `RagEval.evaluate()` docstring at
+  `src/app/sdk/client.py:60` now documents the canonical
+  `ground_truths: list[str]` plural-list shape and explicitly notes
+  the legacy singular `ground_truth=` kwarg is still accepted via the
+  backward-compat shim. The runtime behaviour was already correct in
+  v1.0.0; this fixes the documented contract.
+- **G6-B (built-in RAG pipeline default):** `LLMClient.gemini_model`
+  fallback at `src/app/llm/client.py:52` flipped from the deprecated
+  `gemini-1.5-flash` to `gemini-2.5-flash`, aligning with the eval
+  harness judge default. Affects only the optional built-in RAG
+  pipeline; the eval harness was already on 2.5-flash. Override via
+  the `GEMINI_MODEL` env var as before.
+
+### Verification
+
+- 80 unit tests + 3 schema regression tests pass (the v1.0.0 shim tests
+  for `EvalSample` and `AgentTrace` legacy-kwarg promotion still hold).
+- Test-mock + e2e tests updated to assert against the new `metrics`
+  key on the agent endpoint.
+
 ## [1.0.0] - 2026-05-10
 
 First Production/Stable release. Closes the 2026-05-10 Top-N=4 launch readiness audit (Path A: narrowed scope + authenticity-pass cleanup). Full action list at `docs/audit/T-N4-readiness-2026-05-10.md` in the aiexponent monorepo. G6 Responsible AI sign-off pending re-review against this tag.

--- a/docs/ci-cd-guide.md
+++ b/docs/ci-cd-guide.md
@@ -161,7 +161,7 @@ Because these are deterministic, you can use strict equality assertions in CI:
 with open("reports/retrieval-results.json") as f:
     results = json.load(f)
 
-assert results["scores"]["precision_at_k"] >= 0.65, \
+assert results["metrics"]["precision_at_k"] >= 0.65, \
     f"Retrieval precision dropped: {results['scores']['precision_at_k']:.3f}"
 ```
 
@@ -176,7 +176,7 @@ report = client.evaluate(
     samples,
     metrics=["source_attribution_accuracy"]
 )
-score = report["scores"]["source_attribution_accuracy"]
+score = report["metrics"]["source_attribution_accuracy"]
 assert score >= 0.95, \
     f"Agent is hallucinating source citations: attribution accuracy = {score:.3f}"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rag-benchmarking"
-version = "1.0.0"
+version = "1.0.1"
 description = "Framework-agnostic evaluation harness for RAG and agentic AI systems"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/app/api/evaluate.py
+++ b/src/app/api/evaluate.py
@@ -146,8 +146,14 @@ async def post_evaluate_agent(
             scores[metric] = r["score"]
             details[metric] = r
 
+    # v1.0.1 audit RB-NEW3: renamed `scores` → `metrics` to match the
+    # /v1/evaluate sibling endpoint shape (which has always emitted
+    # `metrics`). Sibling-endpoint contract drift was the only remaining
+    # API contract issue in the v1.0.0 audit. CHANGELOG documents this
+    # as the one breaking change in v1.0.1; consumers reading
+    # `r["scores"]` should switch to `r["metrics"]`.
     return {
-        "scores": scores,
+        "metrics": scores,
         "details": details,
         "trace_id": request.trace.trace_id,
     }

--- a/src/app/llm/client.py
+++ b/src/app/llm/client.py
@@ -49,7 +49,10 @@ class LLMClient:
         settings = get_settings()
         self.provider = (settings.llm_provider or "").lower()
         self.openai_model = settings.openai_model or "gpt-4o-mini"
-        self.gemini_model = settings.gemini_model or "gemini-1.5-flash"
+        # Built-in RAG pipeline default. Aligned with the eval-harness judge
+        # default (RunConfig.judge_model) which moved 1.5 → 2.5 at v1.0.0
+        # (audit RB-H2). Override via the GEMINI_MODEL env var.
+        self.gemini_model = settings.gemini_model or "gemini-2.5-flash"
         self.temperature = settings.llm_temperature
         self.max_tokens = settings.llm_max_tokens
         self.openai_api_key = settings.openai_api_key

--- a/src/app/sdk/client.py
+++ b/src/app/sdk/client.py
@@ -13,7 +13,7 @@ class RagEval:
 
         client = RagEval(api_url="http://localhost:5001", api_key="your-key")
         report = client.evaluate(samples, metrics=["faithfulness", "answer_relevancy"])
-        print(report["scores"])
+        print(report["metrics"])
 
     LangChain integration::
 
@@ -57,9 +57,13 @@ class RagEval:
           - "answer": str
 
         Optional fields:
-          - "ground_truth": str  (enables context_precision, context_recall)
+          - "ground_truths": list[str]  (Ragas convention; enables context_precision, context_recall)
           - "retrieved_doc_ids": list[str]  (enables Precision@K, Recall@K)
           - "relevant_doc_ids": list[str]
+
+        Backward compatibility: the legacy singular ``"ground_truth": str`` key is
+        also accepted and promoted to a single-element ``ground_truths`` list at
+        construction time. Prefer the plural form for new code.
         """
         payload: dict[str, Any] = {"samples": samples}
         if metrics:

--- a/tests/e2e/test_api_harness.py
+++ b/tests/e2e/test_api_harness.py
@@ -63,8 +63,8 @@ def test_agent_eval_endpoint_source_attribution(client):
     resp = client.post("/v1/evaluate/agent", json=payload, headers=HEADERS)
     assert resp.status_code == 200
     data = resp.json()
-    assert "scores" in data
-    assert "source_attribution_accuracy" in data["scores"]
+    assert "metrics" in data
+    assert "source_attribution_accuracy" in data["metrics"]
     assert "trace_id" in data
 
 

--- a/tests/integration/test_sdk.py
+++ b/tests/integration/test_sdk.py
@@ -16,12 +16,12 @@ def test_sdk_evaluate_list_of_dicts():
     with patch("app.sdk.client.requests.post") as mock_post:
         mock_post.return_value.status_code = 200
         mock_post.return_value.json.return_value = {
-            "scores": {"faithfulness": 0.9},
+            "metrics": {"faithfulness": 0.9},
             "run_id": "run-001",
         }
         mock_post.return_value.raise_for_status = MagicMock()
         report = client.evaluate(samples, metrics=["faithfulness"])
-    assert report["scores"]["faithfulness"] == 0.9
+    assert report["metrics"]["faithfulness"] == 0.9
 
 
 def test_sdk_from_langchain_style():


### PR DESCRIPTION
## Summary

Closes the three items the v1.0.0 sign-off round (G6 + Auth Shield re-review) flagged as **non-blocking but tracked**, before they accrue into a larger release. All three are mechanical; all three are documented at file:line in `docs/audit/T-N4-readiness-2026-05-10.md` (§11.3 G6-A, §11.3 G6-B, §11.1 RB-NEW3).

## ⚠ Breaking change (one)

**`/v1/evaluate/agent` response key renamed `scores` → `metrics`.**

Brings the agent endpoint into shape-parity with `/v1/evaluate` (which always emitted `metrics`). Same-day-as-v1.0.0 cut means any consumer who picked up v1.0.0 in the last few hours has the cleanest possible migration path — change one literal.

**Migration:** if your code reads `r[\"scores\"]` from the agent endpoint, change to `r[\"metrics\"]`. The inner per-metric dict is unchanged.

## Other changes (non-breaking)

- **G6-A** — `RagEval.evaluate()` docstring now documents the canonical `ground_truths: list[str]` plural-list shape and the backward-compat acceptance of legacy singular `ground_truth=` via the shim. Runtime behaviour was already correct in v1.0.0; this fixes the documented contract for pip-installed users seeing the docstring via `help()` or IDE introspection.
- **G6-B** — `LLMClient.gemini_model` fallback default `gemini-1.5-flash` → `gemini-2.5-flash`, aligning with the eval-harness judge default. Affects only the optional built-in RAG pipeline; the eval harness was already on 2.5. Override via `GEMINI_MODEL` env var as before.

## Verification

\`\`\`
80/80 unit tests pass
7/7 touched integration + e2e tests pass (assertions updated for the new metrics key)
ruff check + ruff format clean
\`\`\`

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the v1.0.1 tag goes up and `publish-pypi.yml` fires
- [ ] Post-publish: `pip install rag-benchmarking==1.0.1`; `RagEval.evaluate(...)` returns `report[\"metrics\"]`; `/v1/evaluate/agent` returns `{\"metrics\": ...}` not `{\"scores\": ...}`

## What's not in this PR

- Founder's pending decision on flagship promotion (auto-promote vs `featuredOptOut` until v1.1 demand-signal milestone) is unchanged by this release. v1.0.1 is purely a contract-cleanup; it does not address the contrarian-challenger CFO + Domain Expert residual critiques (those are v1.1 milestones — inter-rater κ on agentic metrics + at least one public-benchmark validation run).